### PR TITLE
Export storage helpers

### DIFF
--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -394,3 +394,5 @@ export function checkSmsTransactionExists(messageId: string): boolean {
     return false;
   }
 }
+
+export { getFromStorage, setInStorage as saveToStorage };


### PR DESCRIPTION
## Summary
- export `getFromStorage` and `setInStorage` as helpers
- re-export `setInStorage` under the `saveToStorage` name

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ff5ddb2948333800f99bb1e2e312a