### PR TITLE
Fix SMS parser imports

### DIFF
--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -11,7 +11,7 @@ import DetectedTransactionCard from './smart-paste/DetectedTransactionCard';
 import ErrorAlert from './smart-paste/ErrorAlert';
 import NoTransactionMessage from './smart-paste/NoTransactionMessage';
 import { Switch } from './ui/switch';
-import { parseSmsMessage } from '@/lib/smart-paste-engine/structureParser';
+import { parseSmsMessage } from '@/lib/smart-paste-engine/smsParser';
 import { nanoid } from 'nanoid';
 import { parseAndInferTransaction } from '@/lib/smart-paste-engine/parseAndInferTransaction';
 import { isFinancialTransactionMessage } from '@/lib/smart-paste-engine/messageFilter';

--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -1,6 +1,6 @@
 import { Transaction, TransactionType } from '@/types/transaction';
 import { nanoid } from 'nanoid';
-import { parseSmsMessage } from './structureParser';
+import { parseSmsMessage } from '@/lib/smart-paste-engine/smsParser';
 import { loadKeywordBank } from './keywordBankUtils';
 import { getAllTemplates } from './templateUtils';
 import {

--- a/src/services/SmsProcessingService.ts
+++ b/src/services/SmsProcessingService.ts
@@ -1,5 +1,5 @@
 
-import { parseSmsMessage } from '@/lib/smart-paste-engine/structureParser';
+import { parseSmsMessage } from '@/lib/smart-paste-engine/smsParser';
 import { Transaction } from '@/types/transaction';
 import { SmsReaderService } from './SmsReaderService';
 


### PR DESCRIPTION
## Summary
- adjust imports to use the smsParser module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ff6ac1ef48333b3573dc498190622