### PR TITLE
Add dashboard date range filter

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,11 +11,13 @@ import PageHeader from '@/components/layout/PageHeader';
 import { v4 as uuidv4 } from 'uuid';
 import { Transaction } from '@/types/transaction';
 import { useUser } from '@/context/UserContext';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
 const Dashboard = () => {
   const { transactions, addTransaction } = useTransactions();
   const { user } = useUser();
   const navigate = useNavigate();
+  const [range, setRange] = React.useState<'day' | 'week' | 'month' | 'year'>('month');
 
   const handleAddTransaction = () => {
     navigate('/edit-transaction');
@@ -36,7 +38,31 @@ const Dashboard = () => {
     addTransaction(sampleTransaction);
   };
 
-  const summary = transactions.reduce(
+  const filteredTransactions = React.useMemo(() => {
+    const now = new Date();
+    let start = new Date(now);
+    switch (range) {
+      case 'day':
+        start.setHours(0, 0, 0, 0);
+        break;
+      case 'week':
+        start.setDate(now.getDate() - 6);
+        start.setHours(0, 0, 0, 0);
+        break;
+      case 'month':
+        start = new Date(now.getFullYear(), now.getMonth(), 1);
+        break;
+      case 'year':
+        start = new Date(now.getFullYear(), 0, 1);
+        break;
+    }
+    return transactions.filter(t => {
+      const d = new Date(t.date);
+      return d >= start && d <= now;
+    });
+  }, [transactions, range]);
+
+  const summary = filteredTransactions.reduce(
     (acc, transaction) => {
       if (transaction.amount > 0) {
         acc.income += transaction.amount;
@@ -49,7 +75,7 @@ const Dashboard = () => {
     { income: 0, expenses: 0, balance: 0 }
   );
 
-  const categoryData = transactions
+  const categoryData = filteredTransactions
     .filter(t => t.amount < 0)
     .reduce((acc, transaction) => {
       const { category, amount } = transaction;
@@ -60,7 +86,7 @@ const Dashboard = () => {
       return acc;
     }, {} as Record<string, number>);
 
-  const timelineData = transactions
+  const timelineData = filteredTransactions
     .filter(t => t.amount < 0)
     .reduce((acc, transaction) => {
       const date = transaction.date.slice(0, 10);
@@ -91,6 +117,20 @@ const Dashboard = () => {
           }
         />
 
+        <div className="my-4">
+          <ToggleGroup
+            type="single"
+            value={range}
+            onValueChange={(val) => val && setRange(val as any)}
+            className="justify-start"
+          >
+            <ToggleGroupItem value="day">Day</ToggleGroupItem>
+            <ToggleGroupItem value="week">Week</ToggleGroupItem>
+            <ToggleGroupItem value="month">Month</ToggleGroupItem>
+            <ToggleGroupItem value="year">Year</ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+
         <div className="space-y-[var(--section-gap)]">
           <DashboardStats
             income={summary.income}
@@ -119,9 +159,9 @@ const Dashboard = () => {
                 </Button>
               </div>
 
-              {transactions.length > 0 ? (
+              {filteredTransactions.length > 0 ? (
                 <div className="space-y-2">
-                  {transactions.slice(0, 5).map((transaction) => (
+                  {filteredTransactions.slice(0, 5).map((transaction) => (
                     <div
                       key={transaction.id}
                       className="flex justify-between items-center p-2 bg-secondary/50 rounded-md"


### PR DESCRIPTION
## Summary
- add ToggleGroup to filter dashboard data by day, week, month or year
- filter transactions when computing dashboard stats, charts and list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685010934f608333a713e2d64cc6aba2