### PR TITLE
Fix DashboardStats card layout

### DIFF
--- a/src/components/DashboardStats.tsx
+++ b/src/components/DashboardStats.tsx
@@ -25,7 +25,7 @@ const DashboardStats = ({
   const isPositiveChange = balanceChange >= 0;
   
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+    <div className="grid grid-cols-3 gap-4 mb-6">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
## Summary
- keep income, expense and balance cards in a single row for all viewport sizes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68506c095cb4833382e8b7dfbdd43dfe