### PR TITLE
Add subcategory charts

### DIFF
--- a/src/components/ExpenseChart.tsx
+++ b/src/components/ExpenseChart.tsx
@@ -11,14 +11,14 @@ interface ExpenseByCategory {
   value: number;
 }
 
-interface ExpenseByDate {
-  date: string;
-  amount: number;
+interface ExpenseBySubcategory {
+  name: string;
+  value: number;
 }
 
 interface ExpenseChartProps {
   expensesByCategory: ExpenseByCategory[];
-  expensesByDate: ExpenseByDate[];
+  expensesBySubcategory: ExpenseBySubcategory[];
 }
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#A259FF', '#4BC0C0', '#F87171', '#FB7185'];
@@ -37,12 +37,14 @@ const CustomTooltip = ({ active, payload, label }: any) => {
   return null;
 };
 
-const ExpenseChart = ({ expensesByCategory = [], expensesByDate = [] }: ExpenseChartProps) => {
+const ExpenseChart = ({ expensesByCategory = [], expensesBySubcategory = [] }: ExpenseChartProps) => {
   const [activeTab, setActiveTab] = useState('category');
 
+  const limitedCategoryData = expensesByCategory.slice(0, 5);
+
   // Safe check for empty data
-  const hasExpensesByCategory = Array.isArray(expensesByCategory) && expensesByCategory.length > 0;
-  const hasExpensesByDate = Array.isArray(expensesByDate) && expensesByDate.length > 0;
+  const hasExpensesByCategory = Array.isArray(limitedCategoryData) && limitedCategoryData.length > 0;
+  const hasExpensesBySubcategory = Array.isArray(expensesBySubcategory) && expensesBySubcategory.length > 0;
 
   return (
     <motion.div
@@ -58,7 +60,7 @@ const ExpenseChart = ({ expensesByCategory = [], expensesByDate = [] }: ExpenseC
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
             <TabsList className="mb-4">
               <TabsTrigger value="category">By Category</TabsTrigger>
-              <TabsTrigger value="timeline">Timeline</TabsTrigger>
+              <TabsTrigger value="subcategory">Subcategories</TabsTrigger>
             </TabsList>
             
             <TabsContent value="category" className="pt-2">
@@ -67,7 +69,7 @@ const ExpenseChart = ({ expensesByCategory = [], expensesByDate = [] }: ExpenseC
                   <ResponsiveContainer width="100%" height="100%">
                     <PieChart margin={CHART_MARGIN}>
                       <Pie
-                        data={expensesByCategory}
+                        data={limitedCategoryData}
                         cx="50%"
                         cy="50%"
                         labelLine={false}
@@ -77,7 +79,7 @@ const ExpenseChart = ({ expensesByCategory = [], expensesByDate = [] }: ExpenseC
                         dataKey="value"
                         label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
                       >
-                        {expensesByCategory.map((entry, index) => (
+                        {limitedCategoryData.map((entry, index) => (
                           <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                         ))}
                       </Pie>
@@ -91,22 +93,20 @@ const ExpenseChart = ({ expensesByCategory = [], expensesByDate = [] }: ExpenseC
               )}
             </TabsContent>
             
-            <TabsContent value="timeline" className="pt-2">
-              {hasExpensesByDate ? (
+            <TabsContent value="subcategory" className="pt-2">
+              {hasExpensesBySubcategory ? (
                 <div className="h-[300px] w-full">
                   <ResponsiveContainer width="100%" height="100%">
-                    <BarChart data={expensesByDate} margin={CHART_MARGIN}>
-                      <XAxis dataKey="date" />
-                      <YAxis 
-                        tickFormatter={(value) => formatCurrency(Math.abs(value)).replace(/[^0-9.]/g, '')}
-                      />
+                    <BarChart data={expensesBySubcategory} layout="vertical" margin={CHART_MARGIN}>
+                      <XAxis type="number" tickFormatter={(value) => formatCurrency(Math.abs(value)).replace(/[^0-9.]/g, '')} />
+                      <YAxis type="category" dataKey="name" width={100} />
                       <Tooltip content={<CustomTooltip />} />
-                      <Bar dataKey="amount" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+                      <Bar dataKey="value" fill="hsl(var(--primary))" radius={[4, 4, 4, 4]} />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
               ) : (
-                <p className="text-center text-muted-foreground py-12">No timeline data available</p>
+                <p className="text-center text-muted-foreground py-12">No subcategory data available</p>
               )}
             </TabsContent>
           </Tabs>

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -7,6 +7,7 @@ import { Transaction } from '@/types/transaction';
 import { generateChartData } from '@/lib/mock-data';
 import { motion } from 'framer-motion';
 import { useUser } from '@/context/UserContext';
+import { AnalyticsService } from '@/services/AnalyticsService';
 
 interface DashboardContentProps {
   transactions: Transaction[];
@@ -68,17 +69,17 @@ const DashboardContent = ({
 
   // Generate chart data with error handling
   let categoryData = [];
-  let timelineData = [];
+  let subcategoryData = [];
   
   try {
     const chartData = generateChartData(safeTransactions);
     categoryData = chartData.categoryData || [];
-    timelineData = chartData.timelineData || [];
+    subcategoryData = AnalyticsService.getSubcategoryData(safeTransactions).slice(0, 10);
   } catch (error) {
     console.error('Error generating chart data:', error);
     // Provide empty arrays as fallback
     categoryData = [];
-    timelineData = [];
+    subcategoryData = [];
   }
 
   // Placeholder skeleton for loading state
@@ -131,9 +132,9 @@ const DashboardContent = ({
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.4, delay: 0.1 }}
         >
-          <ExpenseChart 
+          <ExpenseChart
             expensesByCategory={categoryData}
-            expensesByDate={timelineData}
+            expensesBySubcategory={subcategoryData}
           />
         </motion.div>
         

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Transaction } from '@/types/transaction';
 import { useUser } from '@/context/UserContext';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { AnalyticsService } from '@/services/AnalyticsService';
 
 const Dashboard = () => {
   const { transactions, addTransaction } = useTransactions();
@@ -97,23 +98,10 @@ const Dashboard = () => {
       return acc;
     }, {} as Record<string, number>);
 
-  const timelineData = filteredTransactions
-    .filter(t => t.amount < 0)
-    .reduce((acc, transaction) => {
-      const date = transaction.date.slice(0, 10);
-      if (!acc[date]) {
-        acc[date] = 0;
-      }
-      acc[date] += Math.abs(transaction.amount);
-      return acc;
-    }, {} as Record<string, number>);
+  const expensesBySubcategory = AnalyticsService.getSubcategoryData(filteredTransactions).slice(0, 10);
 
   const expensesByCategory = Object.entries(categoryData)
     .map(([name, value]) => ({ name, value }));
-
-  const expensesByDate = Object.entries(timelineData)
-    .map(([date, amount]) => ({ date, amount }))
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
   return (
     <Layout>
@@ -175,7 +163,7 @@ const Dashboard = () => {
               <h2 className="text-lg font-semibold mb-2">Expense Breakdown</h2>
               <ExpenseChart
                 expensesByCategory={expensesByCategory}
-                expensesByDate={expensesByDate}
+                expensesBySubcategory={expensesBySubcategory}
               />
             </div>
 

--- a/src/services/AnalyticsService.ts
+++ b/src/services/AnalyticsService.ts
@@ -53,6 +53,24 @@ export class AnalyticsService {
       .sort((a, b) => b.value - a.value);
   }
 
+  // Generate data for the subcategory breakdown chart
+  static getSubcategoryData(transactions: Transaction[]): CategoryData[] {
+    const expensesBySubcategory = transactions
+      .filter(t => t.amount < 0 && t.subcategory)
+      .reduce((acc: Record<string, number>, transaction) => {
+        const sub = transaction.subcategory as string;
+        if (!acc[sub]) {
+          acc[sub] = 0;
+        }
+        acc[sub] += Math.abs(transaction.amount);
+        return acc;
+      }, {});
+
+    return Object.entries(expensesBySubcategory)
+      .map(([name, value]) => ({ name, value }))
+      .sort((a, b) => b.value - a.value);
+  }
+
   // Generate data for the monthly spending chart
   static getMonthlyData(transactions: Transaction[]): MonthlyData[] {
     // Filter out transactions that don't have a date field or have amount >= 0


### PR DESCRIPTION
## Summary
- add `getSubcategoryData` helper to AnalyticsService
- compute and pass subcategory data to Dashboard components
- update ExpenseChart with subcategory tab and category limit

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685075f2673c83338f7023e157ed309b