### PR TITLE
Use CSS variable for card padding

### DIFF
--- a/src/components/DashboardStats.tsx
+++ b/src/components/DashboardStats.tsx
@@ -32,7 +32,7 @@ const DashboardStats = ({
         transition={{ duration: 0.3, delay: 0.1 }}
       >
         <Card className="overflow-hidden border border-border">
-          <CardContent className="p-6">
+          <CardContent className="p-[var(--card-padding)]">
             <div className="flex justify-between items-start">
               <p className="flex-1 text-center text-sm font-medium text-muted-foreground">Income</p>
               <ArrowUpCircle className="text-green-600" size={20} />
@@ -48,7 +48,7 @@ const DashboardStats = ({
         transition={{ duration: 0.3, delay: 0.2 }}
       >
         <Card className="overflow-hidden border border-border">
-          <CardContent className="p-6">
+          <CardContent className="p-[var(--card-padding)]">
             <div className="flex justify-between items-start">
               <p className="flex-1 text-center text-sm font-medium text-muted-foreground">Expenses</p>
               <ArrowDownCircle className="text-red-600" size={20} />
@@ -64,7 +64,7 @@ const DashboardStats = ({
         transition={{ duration: 0.3, delay: 0.3 }}
       >
         <Card className="overflow-hidden border border-border">
-          <CardContent className="p-6">
+          <CardContent className="p-[var(--card-padding)]">
             <div className="flex justify-between items-start">
               <p className="flex-1 text-center text-sm font-medium text-muted-foreground">Balance</p>
               <div className={`${balance >= 0 ? 'text-blue-600' : 'text-red-600'}`}> 

--- a/src/components/SmartPasteSummary.tsx
+++ b/src/components/SmartPasteSummary.tsx
@@ -18,7 +18,7 @@ const SmartPasteSummary: React.FC<Props> = ({
   keywordScore 
 }) => {
   return (
-    <Card className="bg-purple-50 border-l-4 border-purple-600 text-purple-900 p-4 text-sm rounded-md">
+    <Card className="bg-purple-50 border-l-4 border-purple-600 text-purple-900 p-[var(--card-padding)] text-sm rounded-md">
       <h2 className="font-semibold mb-2 text-purple-800">
         🧠 SmartPaste Summary
       </h2>

--- a/src/components/SmsPermissionRequest.tsx
+++ b/src/components/SmsPermissionRequest.tsx
@@ -84,7 +84,7 @@ const SmsPermissionRequest: React.FC<SmsPermissionRequestProps> = ({
   // If not in a native environment, show a web fallback message
   if (!smsPermissionService.isNativeEnvironment()) {
     return (
-      <div className={`bg-yellow-50 border border-yellow-100 rounded-lg p-4 ${className}`}>
+      <div className={`bg-yellow-50 border border-yellow-100 rounded-lg p-[var(--card-padding)] ${className}`}>
         <div className="flex items-start gap-3">
           <AlertTriangle className="text-yellow-500 flex-shrink-0" size={20} />
           <div>
@@ -100,7 +100,7 @@ const SmsPermissionRequest: React.FC<SmsPermissionRequestProps> = ({
 
   if (permissionGranted) {
     return (
-      <div className={`bg-green-50 border border-green-100 rounded-lg p-4 ${className}`}>
+      <div className={`bg-green-50 border border-green-100 rounded-lg p-[var(--card-padding)] ${className}`}>
         <div className="flex items-start gap-3">
           <Check className="text-green-600 flex-shrink-0" size={20} />
           <div>
@@ -115,7 +115,7 @@ const SmsPermissionRequest: React.FC<SmsPermissionRequestProps> = ({
   }
 
   return (
-    <div className={`border rounded-lg p-4 ${className}`}>
+    <div className={`border rounded-lg p-[var(--card-padding)] ${className}`}>
       <div className="flex flex-col items-center text-center">
         <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mb-4">
           <MessageSquare className="h-6 w-6 text-primary" />

--- a/src/components/analytics/SummaryCards.tsx
+++ b/src/components/analytics/SummaryCards.tsx
@@ -19,7 +19,7 @@ const SummaryCards = ({ totals }: SummaryCardsProps) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <Card className="border border-border shadow-sm hover:shadow-md transition-shadow">
-        <CardContent className="p-6">
+        <CardContent className="p-[var(--card-padding)]">
           <div className="flex items-center justify-between mb-2">
             <p className="text-sm font-medium text-muted-foreground">Total Income</p>
             <div className="h-8 w-8 rounded-full bg-green-100 flex items-center justify-center">
@@ -36,7 +36,7 @@ const SummaryCards = ({ totals }: SummaryCardsProps) => {
       </Card>
       
       <Card className="border border-border shadow-sm hover:shadow-md transition-shadow">
-        <CardContent className="p-6">
+        <CardContent className="p-[var(--card-padding)]">
           <div className="flex items-center justify-between mb-2">
             <p className="text-sm font-medium text-muted-foreground">Total Expenses</p>
             <div className="h-8 w-8 rounded-full bg-red-100 flex items-center justify-center">
@@ -53,7 +53,7 @@ const SummaryCards = ({ totals }: SummaryCardsProps) => {
       </Card>
       
       <Card className="border border-border shadow-sm hover:shadow-md transition-shadow">
-        <CardContent className="p-6">
+        <CardContent className="p-[var(--card-padding)]">
           <div className="flex items-center justify-between mb-2">
             <p className="text-sm font-medium text-muted-foreground">Savings Rate</p>
             <div className="h-8 w-8 rounded-full bg-blue-100 flex items-center justify-center">

--- a/src/components/settings/CategorySettings.tsx
+++ b/src/components/settings/CategorySettings.tsx
@@ -180,7 +180,7 @@ const CategorySettings = () => {
                 <ScrollArea className="h-[500px] pr-4">
                   <div className="space-y-4">
                     {categoryRules.map((rule) => (
-                      <Card key={rule.id} className="p-4">
+                      <Card key={rule.id} className="p-[var(--card-padding)]">
                         <div className="flex flex-col space-y-2">
                           <div className="flex justify-between items-start">
                             <div>
@@ -253,7 +253,7 @@ const CategorySettings = () => {
                 <ScrollArea className="h-[500px] pr-4">
                   <div className="space-y-4">
                     {ruleSuggestions.map((suggestion, index) => (
-                      <Card key={index} className="p-4">
+                      <Card key={index} className="p-[var(--card-padding)]">
                         <div className="flex flex-col space-y-2">
                           <div className="flex justify-between items-start">
                             <div>

--- a/src/components/smart-paste/DetectedTransactionCard.tsx
+++ b/src/components/smart-paste/DetectedTransactionCard.tsx
@@ -38,7 +38,7 @@ const DetectedTransactionCard = ({
 
   return (
     <Card className="overflow-hidden">
-      <CardContent className="p-4">
+      <CardContent className="p-[var(--card-padding)]">
         <div className="flex justify-between items-start">
           <div>
             <div className="flex items-center gap-2">

--- a/src/components/transactions/SwipeableTransactionCard.tsx
+++ b/src/components/transactions/SwipeableTransactionCard.tsx
@@ -52,7 +52,7 @@ const SwipeableTransactionCard: React.FC<SwipeableTransactionCardProps> = ({
   // Don't use swipe on desktop
   if (!isMobile) {
     return (
-      <Card className="p-4">
+      <Card className="p-[var(--card-padding)]">
         <div className="flex justify-between items-center">
           <div>
             <h4 className="font-medium">{transaction.title}</h4>
@@ -105,7 +105,7 @@ const SwipeableTransactionCard: React.FC<SwipeableTransactionCardProps> = ({
         animate={controls}
         className="relative bg-card rounded-lg shadow z-10"
       >
-        <Card className="p-4 cursor-grab active:cursor-grabbing">
+        <Card className="p-[var(--card-padding)] cursor-grab active:cursor-grabbing">
           <div className="flex justify-between items-center">
             <div>
               <h4 className="font-medium">{transaction.title}</h4>

--- a/src/components/transactions/TransactionCard.tsx
+++ b/src/components/transactions/TransactionCard.tsx
@@ -77,8 +77,8 @@
 			  transition={{ duration: 0.2 }}
 			  className={className}
 			>
-			  <Card className="overflow-hidden border hover:shadow-md transition-all duration-200">
-				<CardContent className="p-4">
+                          <Card className="overflow-hidden border hover:shadow-md transition-all duration-200">
+                                <CardContent className="p-[var(--card-padding)]">
 				  <div className="flex items-center justify-between">
 					<div className="flex items-center space-x-3">
 					  <div className={cn(

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -152,7 +152,7 @@ const TransactionList: React.FC<TransactionListProps> = ({
   if (isLoading) {
     return (
       <Card>
-        <div className="p-4">
+        <div className="p-[var(--card-padding)]">
           <div className="space-y-3">
             {Array.from({ length: 5 }).map((_, i) => (
               <div key={i} className="flex items-center justify-between">
@@ -173,7 +173,7 @@ const TransactionList: React.FC<TransactionListProps> = ({
   if (transactions.length === 0) {
     return (
       <Card>
-        <div className="p-6 text-center">
+        <div className="p-[var(--card-padding)] text-center">
           <p className="text-muted-foreground">{emptyMessage}</p>
         </div>
       </Card>
@@ -186,7 +186,7 @@ const TransactionList: React.FC<TransactionListProps> = ({
       <div className="space-y-3">
         {transactions.map(transaction => (
           <Card key={transaction.id} className="overflow-hidden">
-            <div className="p-4">
+            <div className="p-[var(--card-padding)]">
               <div className="flex justify-between items-start mb-2">
                 <div>
                   <h3 className="font-medium">{transaction.title}</h3>

--- a/src/components/transactions/TransactionsByDate.tsx
+++ b/src/components/transactions/TransactionsByDate.tsx
@@ -54,7 +54,7 @@ const TransactionsByDate: React.FC<TransactionsByDateProps> = ({
   }
 
   return (
-    <Card key={transaction.id?.trim() || `txn-${date}-${index}`} className="p-4">
+    <Card key={transaction.id?.trim() || `txn-${date}-${index}`} className="p-[var(--card-padding)]">
       <div className="flex justify-between items-center">
         <div className="flex-1">
           <h4 className="font-medium">{transaction.title}</h4>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -24,7 +24,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1 p-2", className)}
+    className={cn("flex flex-col space-y-1 p-[var(--card-padding)]", className)}
     {...props}
   />
 ))
@@ -61,7 +61,11 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-2 pt-0", className)} {...props} />
+  <div
+    ref={ref}
+    className={cn("p-[var(--card-padding)] pt-0", className)}
+    {...props}
+  />
 ))
 CardContent.displayName = "CardContent"
 
@@ -71,7 +75,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-2 pt-0", className)}
+    className={cn("flex items-center p-[var(--card-padding)] pt-0", className)}
     {...props}
   />
 ))

--- a/src/index.css
+++ b/src/index.css
@@ -101,9 +101,10 @@
 }
 
 @layer components {
-  .card {
-    @apply bg-card border border-border rounded-lg shadow-sm p-2;
-  }
+.card {
+  @apply bg-card border border-border rounded-lg shadow-sm;
+  padding: var(--card-padding);
+}
 }
 
 /* Mobile-specific optimizations */

--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -195,7 +195,7 @@ const handleReadSms = async () => {
         {filteredMessages
           .filter((msg): msg is ProcessedSmsEntry => !!msg && typeof msg.sender === 'string')
           .map((msg, index) => (
-            <Card key={index} className="p-4">
+            <Card key={index} className="p-[var(--card-padding)]">
               <p><strong>From:</strong> {msg.sender}</p>
               <p><strong>Date:</strong> {new Date(msg.date).toLocaleString()}</p>
               <p><strong>Message:</strong> {msg.message}</p>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -333,7 +333,7 @@ const Profile = () => {
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.3, delay: 0.5 }}
-            className="bg-primary/5 border border-primary/20 rounded-lg p-4 text-center space-y-3"
+            className="bg-primary/5 border border-primary/20 rounded-lg p-[var(--card-padding)] text-center space-y-3"
           >
             <h3 className="font-semibold">Complete Your Setup</h3>
             <p className="text-sm text-muted-foreground">

--- a/src/pages/ReviewDraftTransactions.tsx
+++ b/src/pages/ReviewDraftTransactions.tsx
@@ -167,7 +167,7 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
       </div>
 
       {transactions.map((txn, index) => (
-        <Card key={index} className="p-4 mb-4">
+        <Card key={index} className="p-[var(--card-padding)] mb-4">
           <p className="mb-2 text-sm text-gray-500">{txn.rawMessage}</p>
           <div className="grid grid-cols-2 gap-2">
             <input value={txn.vendor} onChange={e => handleFieldChange(index, 'vendor', e.target.value)} className="border rounded p-2" />

--- a/src/pages/SmsProviderSelection.tsx
+++ b/src/pages/SmsProviderSelection.tsx
@@ -134,7 +134,7 @@ const SmsProviderSelection = () => {
           <motion.div 
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
-            className="bg-green-50 border border-green-200 rounded-lg p-4 flex items-start gap-3"
+            className="bg-green-50 border border-green-200 rounded-lg p-[var(--card-padding)] flex items-start gap-3"
           >
             <Check className="text-green-500 mt-0.5" size={18} />
             <div>
@@ -159,7 +159,7 @@ const SmsProviderSelection = () => {
         {isLoading ? (
           <div className="space-y-2">
             {Array.from({ length: 3 }).map((_, index) => (
-              <div key={index} className="p-4 border rounded-lg animate-pulse">
+              <div key={index} className="p-[var(--card-padding)] border rounded-lg animate-pulse">
                 <div className="h-5 bg-gray-200 rounded w-3/4 mb-2"></div>
                 <div className="h-4 bg-gray-100 rounded w-full"></div>
               </div>
@@ -174,7 +174,7 @@ const SmsProviderSelection = () => {
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.3 }}
-                  className={`p-4 border rounded-lg flex items-center justify-between cursor-pointer ${
+                  className={`p-[var(--card-padding)] border rounded-lg flex items-center justify-between cursor-pointer ${
                     provider.isSelected 
                       ? 'bg-primary/5 border-primary' 
                       : 'hover:bg-secondary'

--- a/src/pages/TrainModel.tsx
+++ b/src/pages/TrainModel.tsx
@@ -445,7 +445,7 @@ const TrainModel = () => {
         <div className="grid grid-cols-1 gap-6 md:grid-cols-12">
           <div className="md:col-span-8">
             <Card className="mb-6">
-              <CardContent className="p-4">
+              <CardContent className="p-[var(--card-padding)]">
                 <p className="text-sm font-medium mb-2">Message</p>
                 <Textarea
                   ref={textareaRef}
@@ -468,7 +468,7 @@ const TrainModel = () => {
             
             {selections.length > 0 && (
               <Card className="mb-6">
-                <CardContent className="p-4">
+                <CardContent className="p-[var(--card-padding)]">
                   <h3 className="text-sm font-medium mb-2">Tagged Selections</h3>
                   <div className="space-y-2">
                     {selections.map((selection) => (

--- a/src/pages/VendorMapping.tsx
+++ b/src/pages/VendorMapping.tsx
@@ -114,7 +114,7 @@ const VendorMapping: React.FC = () => {
 
       <div className="space-y-4">
         {vendors.map((vendor, index) => (
-          <Card key={vendor.vendor} className="p-4">
+          <Card key={vendor.vendor} className="p-[var(--card-padding)]">
             <div className="mb-2">
               <label className="block mb-1 font-semibold">Vendor:</label>
               <input

--- a/src/pages/VendorTablePage.tsx
+++ b/src/pages/VendorTablePage.tsx
@@ -43,11 +43,11 @@ const VendorTablePage: React.FC = () => {
   };
 
   return (
-    <div className="p-4">
+    <div className="p-[var(--card-padding)]">
       <h1 className="text-2xl font-bold mb-6">Review Vendors</h1>
 
       {vendors.map((vendorEntry, index) => (
-        <Card key={index} className="p-4 mb-4 flex flex-col gap-2">
+        <Card key={index} className="p-[var(--card-padding)] mb-4 flex flex-col gap-2">
           <p><strong>Vendor:</strong> {vendorEntry.vendor}</p>
 
           <div className="flex gap-4">

--- a/src/pages/dev/components/ConfidenceDisplay.tsx
+++ b/src/pages/dev/components/ConfidenceDisplay.tsx
@@ -27,7 +27,7 @@ const ConfidenceDisplay: React.FC<ConfidenceBreakdownProps> = ({
         {isLabelingMode ? "Label Analysis" : "Confidence Breakdown"}
       </h3>
       <Card className="bg-muted/30">
-        <CardContent className="p-4 space-y-2">
+        <CardContent className="p-[var(--card-padding)] space-y-2">
           <div className="grid grid-cols-2 gap-2">
             <div className="text-sm">
               <span className="text-muted-foreground">Matched Fields:</span>

--- a/src/pages/sms/ProcessVendors.tsx
+++ b/src/pages/sms/ProcessVendors.tsx
@@ -50,12 +50,12 @@ const ProcessVendors: React.FC = () => {
   };
 
   return (
-    <div className="p-4">
+    <div className="p-[var(--card-padding)]">
       <h1 className="text-2xl font-bold mb-4">Vendor Categorization</h1>
 
       <div className="space-y-4">
         {vendors.map((vendor, index) => (
-          <Card key={index} className="p-4 flex flex-col space-y-2">
+          <Card key={index} className="p-[var(--card-padding)] flex flex-col space-y-2">
             <p><strong>Vendor:</strong> {vendor.vendor}</p>
 
             <Select

--- a/src/pages/sms/VendorCategorization.tsx
+++ b/src/pages/sms/VendorCategorization.tsx
@@ -72,12 +72,12 @@ const VendorCategorization: React.FC = () => {
   };
 
   return (
-    <div className="p-4">
+    <div className="p-[var(--card-padding)]">
       <h1 className="text-2xl font-bold mb-4">Vendor Categorization</h1>
 
       <div className="space-y-4">
         {vendors.map((vendor, index) => (
-          <Card key={index} className="p-4">
+          <Card key={index} className="p-[var(--card-padding)]">
             <p className="font-semibold mb-2">{vendor.vendor}</p>
 
             <div className="flex gap-4 mb-2">


### PR DESCRIPTION
## Summary
- rely on `--card-padding` variable across card components
- add explicit padding var to `.card` CSS rule
- standardize card padding in components and pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68512b1ce51c8333a872db2ed9fa7df1