### PR TITLE
Remove redundant heading in AddTransaction

### DIFF
--- a/src/pages/AddTransaction.tsx
+++ b/src/pages/AddTransaction.tsx
@@ -48,7 +48,7 @@ const AddTransaction = () => {
 
         <Card className="w-full">
           <CardHeader className="pb-2">
-            <CardTitle>Create a new transaction</CardTitle>
+            {/* <CardTitle>Create a new transaction</CardTitle> */}
           </CardHeader>
           <CardContent className="pt-0">
             <TransactionEditForm onSave={handleSave} />


### PR DESCRIPTION
## Summary
- comment out the extra `<CardTitle>` in `AddTransaction` so the form renders without a secondary heading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: ENETUNREACH when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_6851504209fc833397b913279f80f4d0