### PR TITLE
Fix bottom nav overlap on dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -259,7 +259,7 @@ const Dashboard = () => {
                 <p className="text-center text-muted-foreground py-6">No transactions found for this period.</p>
               )}
 
-              <div className="flex justify-end mt-3">
+              <div className="flex justify-end mt-3 mb-16">
                 <button
                   onClick={() => navigate('/transactions')}
                   aria-label="View full transaction history"


### PR DESCRIPTION
## Summary
- ensure the `View All` button on the dashboard clears the bottom nav

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851561cba048333b9203e5f008e16e6