### PR TITLE
Ensure form submit button stays visible

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -170,7 +170,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({ transaction, 
   return (
     <form
       onSubmit={handleSubmit}
-      className="bg-white p-4 rounded-md shadow-sm grid grid-cols-1 md:grid-cols-2 gap-3"
+      className="bg-white p-4 rounded-md shadow-sm grid grid-cols-1 md:grid-cols-2 gap-3 mb-28"
     >
       <div className="col-span-2 space-y-2">
         <label className="text-sm font-medium text-gray-700">Transaction Type*</label>


### PR DESCRIPTION
## Summary
- add bottom margin to `TransactionEditForm` so the submit button stays visible when scrolling on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68515a37216c83339b05f37fdc781d94