### PR TITLE
Reduce header padding

### DIFF
--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -24,7 +24,7 @@ const PageHeader = ({
 
   return (
     <div className="sticky top-[var(--header-height)] z-20 bg-background/95 backdrop-blur-xl border-b">
-      <div className="px-[var(--page-padding-x)] py-2.5">
+      <div className="px-[var(--page-padding-x)] py-1.5">
         <div className={cn("flex items-center justify-between gap-2", className)}>
           <div className="flex items-center gap-2">
             {showBack && (


### PR DESCRIPTION
## Summary
- shrink the page header padding so the greeting sits closer to the main header

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685168ab92f88333ad374089548cd6da