### PR TITLE
Fix FAB position above bottom nav

### DIFF
--- a/src/components/dashboard/ResponsiveFAB.tsx
+++ b/src/components/dashboard/ResponsiveFAB.tsx
@@ -10,7 +10,7 @@ const ResponsiveFAB: React.FC<ResponsiveFABProps> = ({ onClick }) => (
   <Button
     onClick={onClick}
     size="icon"
-    className="md:hidden fixed bottom-4 right-4 z-40 h-12 w-12 rounded-full bg-primary text-primary-foreground shadow-lg"
+    className="md:hidden fixed bottom-16 right-4 z-40 h-12 w-12 rounded-full bg-primary text-primary-foreground shadow-lg"
     aria-label="Add Transaction"
   >
     <Plus className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- adjust `ResponsiveFAB` position so floating action button clears the bottom nav

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68516d1a30d08333891897e1ce7d9b83