### PR TITLE
Adjust Dashboard chart spacing

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -208,7 +208,7 @@ const Dashboard = () => {
           )}
         </div>
 
-        <div className="space-y-[var(--section-gap)]">
+        <div className="space-y-[calc(var(--section-gap)/2)]">
           <DashboardStats
             income={summary.income}
             expenses={summary.expenses}
@@ -217,7 +217,6 @@ const Dashboard = () => {
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-[var(--card-gap)]">
             <div className="bg-card p-[var(--card-padding)] rounded-lg shadow">
-              <h2 className="text-lg font-semibold mb-2">Expense Breakdown</h2>
               <ExpenseChart
                 expensesByCategory={expensesByCategory}
                 expensesBySubcategory={expensesBySubcategory}


### PR DESCRIPTION
## Summary
- slim down spacing above ExpenseChart and remove its header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: connect ENETUNREACH 140.82.112.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_68516dbd4c84833391ed995ebaa7ff18