### PR TITLE
Align 'View All' button to left

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -258,7 +258,7 @@ const Dashboard = () => {
                 <p className="text-center text-muted-foreground py-6">No transactions found for this period.</p>
               )}
 
-              <div className="flex justify-end mt-3 mb-16">
+              <div className="flex justify-start mt-3 mb-16">
                 <button
                   onClick={() => navigate('/transactions')}
                   aria-label="View full transaction history"


### PR DESCRIPTION
## Summary
- keep bottom margin for FAB clearance
- left-align "View All" button in Recent Transactions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: ENETUNREACH to github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68514eee223083338328c03366e73a3b