### PR TITLE
Align 'View All' button to left

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -170,9 +170,9 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({ transaction, 
   return (
     <form
       onSubmit={handleSubmit}
-      className="bg-white p-4 rounded-md shadow-sm space-y-3 mb-24"
+      className="bg-white p-4 rounded-md shadow-sm grid grid-cols-1 md:grid-cols-2 gap-3 mb-28"
     >
-      <div className="space-y-2">
+      <div className="space-y-2 md:col-span-2">
         <label className="text-sm font-medium text-gray-700">Transaction Type*</label>
         <Select
           value={editedTransaction.type}
@@ -324,7 +324,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({ transaction, 
       </div>
 
       {availableSubcategories.length > 0 && (
-        <div className="space-y-2">
+        <div className="space-y-2 md:col-span-2">
           <label className="text-sm font-medium text-gray-700">Subcategory</label>
           <Select
             value={editedTransaction.subcategory || 'none'}
@@ -348,7 +348,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({ transaction, 
         </div>
       )}
 
-      <div className="space-y-2">
+      <div className="space-y-2 md:col-span-2">
         <label className="text-sm font-medium text-gray-700">Description (Optional)</label>
         <Textarea
           value={editedTransaction.description || ''}
@@ -362,7 +362,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({ transaction, 
         />
       </div>
 
-      <div className="space-y-2">
+      <div className="space-y-2 md:col-span-2">
         <label className="text-sm font-medium text-gray-700">Notes (Optional)</label>
         <Textarea
           value={editedTransaction.notes || ''}
@@ -373,7 +373,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({ transaction, 
         />
       </div>
 
-      <div className="flex justify-end pt-4">
+      <div className="flex justify-end pt-4 md:col-span-2">
         <Button type="submit" className="flex items-center gap-1">
           <Check className="h-4 w-4" />
           {transaction ? 'Update Transaction' : 'Create Transaction'}

--- a/src/pages/AddTransaction.tsx
+++ b/src/pages/AddTransaction.tsx
@@ -6,7 +6,6 @@ import {
   Card,
   CardContent,
   CardHeader,
-  CardTitle,
 } from '@/components/ui/card';
 import { useTransactions } from '@/context/TransactionContext';
 import TransactionEditForm from '@/components/TransactionEditForm';
@@ -35,15 +34,11 @@ const AddTransaction = () => {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="w-full py-[var(--page-padding-y)] space-y-4 sm:space-y-6 px-[var(--page-padding-x)]"
+        className="w-full px-[var(--page-padding-x)]"
       >
 
-        <h1 className="text-xl sm:text-2xl font-bold">Add Transaction</h1>
-
         <Card className="w-full">
-          <CardHeader className="pb-2">
-            {/* <CardTitle>Create a new transaction</CardTitle> */}
-          </CardHeader>
+          <CardHeader className="pb-2" />
           <CardContent className="pt-0">
             <TransactionEditForm onSave={handleSave} />
           </CardContent>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -258,7 +258,7 @@ const Dashboard = () => {
                 <p className="text-center text-muted-foreground py-6">No transactions found for this period.</p>
               )}
 
-              <div className="flex justify-end mt-3 mb-16">
+              <div className="flex justify-start mt-3 mb-16">
                 <button
                   onClick={() => navigate('/transactions')}
                   aria-label="View full transaction history"

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -57,11 +57,8 @@ const EditTransaction = () => {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="w-full py-4 sm:py-[var(--page-padding-y)] space-y-4 sm:space-y-6 px-[var(--page-padding-x)] sm:px-[var(--page-padding-x)]"
+        className="w-full px-[var(--page-padding-x)] space-y-4"
       >
-        <h1 className="text-xl sm:text-2xl font-bold">
-          {isNewTransaction ? 'Add Transaction' : 'Edit Transaction'}
-        </h1>
 
         {isSuggested && (
           <Alert>


### PR DESCRIPTION
## Summary
- keep bottom margin for FAB clearance
- left-align "View All" button in Recent Transactions
- remove Add Transaction header and extra padding
- keep Edit Transaction page compact
- shrink spacing between form fields
- convert TransactionEditForm to two-column layout
- remove leftover card title comment in Add Transaction page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68514eee223083338328c03366e73a3b