### PR TITLE
Add background SMS receiver and service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,18 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <receiver
+            android:name="app.xpensia.com.plugins.backgroundsmslistener.SmsBroadcastReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name="app.xpensia.com.plugins.backgroundsmslistener.SmsProcessingService"
+            android:exported="false" />
     </application>
 
     <!-- Permissions -->
@@ -41,6 +53,7 @@
     <!-- SMS permissions with high priority -->
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     
     <!-- Network state monitoring -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsBroadcastReceiver.java
+++ b/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsBroadcastReceiver.java
@@ -1,0 +1,52 @@
+package app.xpensia.com.plugins.backgroundsmslistener;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.provider.Telephony;
+import android.telephony.SmsMessage;
+import android.util.Log;
+
+import androidx.core.content.ContextCompat;
+
+public class SmsBroadcastReceiver extends BroadcastReceiver {
+    private static final String TAG = "SmsBroadcastReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (Telephony.Sms.Intents.SMS_RECEIVED_ACTION.equals(intent.getAction())) {
+            SmsMessage[] messages = null;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                messages = Telephony.Sms.Intents.getMessagesFromIntent(intent);
+            } else {
+                Object[] pdus = (Object[]) intent.getExtras().get("pdus");
+                if (pdus != null) {
+                    messages = new SmsMessage[pdus.length];
+                    for (int i = 0; i < pdus.length; i++) {
+                        messages[i] = SmsMessage.createFromPdu((byte[]) pdus[i]);
+                    }
+                }
+            }
+
+            if (messages != null && messages.length > 0) {
+                StringBuilder bodyBuilder = new StringBuilder();
+                String sender = messages[0].getOriginatingAddress();
+
+                for (SmsMessage message : messages) {
+                    bodyBuilder.append(message.getMessageBody());
+                }
+                String body = bodyBuilder.toString();
+
+                Log.d(TAG, "SMS received from " + sender + ": " + body);
+
+                Intent serviceIntent = new Intent(context, SmsProcessingService.class);
+                serviceIntent.putExtra("sender", sender);
+                serviceIntent.putExtra("body", body);
+
+                ContextCompat.startForegroundService(context, serviceIntent);
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsProcessingService.java
+++ b/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsProcessingService.java
@@ -1,0 +1,70 @@
+package app.xpensia.com.plugins.backgroundsmslistener;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+
+import com.getcapacitor.JSObject;
+
+public class SmsProcessingService extends Service {
+    private static final String TAG = "SmsProcessingService";
+    private static final String CHANNEL_ID = "SmsProcessingChannel";
+    private static final int NOTIFICATION_ID = 1;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("SMS Listener")
+            .setContentText("Processing incoming SMS")
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .build();
+        startForeground(NOTIFICATION_ID, notification);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        String sender = intent.getStringExtra("sender");
+        String body = intent.getStringExtra("body");
+
+        if (sender != null && body != null) {
+            Log.d(TAG, "Processing SMS from " + sender + ": " + body);
+            BackgroundSmsListenerPlugin.notifySmsReceived(sender, body);
+        }
+
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        Log.d(TAG, "SmsProcessingService destroyed");
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                "SMS Processing",
+                NotificationManager.IMPORTANCE_LOW
+            );
+            NotificationManager manager = getSystemService(NotificationManager.class);
+            if (manager != null) {
+                manager.createNotificationChannel(channel);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SmsBroadcastReceiver` to capture incoming SMS and forward to a service
- implement `SmsProcessingService` as a foreground service
- start/stop this service from `BackgroundSmsListenerPlugin`
- register the new receiver and service in `AndroidManifest`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew assembleDebug` *(fails: Java home supplied is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6851b96345dc833393f041df9b27dfe8