### PR TITLE
Adjust safe area handling for mobile

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -32,7 +32,8 @@ const Layout = ({
     <div
       className={cn(
         "min-h-screen flex flex-col",
-        "pt-[var(--safe-area-top)]", // Safe area for status bar
+        // Only apply safe area padding when no header is shown
+        !showHeader && "pt-[var(--safe-area-top)]",
         className
       )}
     >

--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -174,7 +174,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({ transaction, 
     >
 
       <div className="flex items-center gap-2">
-        <label className="w-32 text-sm font-semibold text-gray-700">Transaction Type*</label>
+        <label className="w-32 text-sm font-semibold text-gray-700">Type*</label>
 
         <Select
           value={editedTransaction.type}

--- a/src/pages/AddTransaction.tsx
+++ b/src/pages/AddTransaction.tsx
@@ -29,12 +29,12 @@ const AddTransaction = () => {
   };
 
   return (
-    <Layout showBack>
+    <Layout showBack withPadding={false} fullWidth>
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="w-full px-[var(--page-padding-x)]"
+        className="w-full px-1"
       >
 
         <Card className="w-full">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -171,13 +171,13 @@ const Dashboard = () => {
     .map(([name, value]) => ({ name, value }));
 
   return (
-    <Layout>
-      <div className="px-[var(--page-padding-x)]">
+    <Layout withPadding={false} fullWidth>
+      <div className="px-1">
         <PageHeader
           title={<AvatarGreeting user={user} tip={tip} />}
         />
 
-        <div className="my-4">
+        <div className="my-2">
           <ToggleGroup
             type="single"
             value={range}

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -52,12 +52,12 @@ const EditTransaction = () => {
   };
 
   return (
-    <Layout showBack>
+    <Layout showBack withPadding={false} fullWidth>
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="w-full px-[var(--page-padding-x)] space-y-4"
+        className="w-full px-1 space-y-4"
       >
 
         {isSuggested && (


### PR DESCRIPTION
## Summary
- avoid double safe-area padding by only applying when no header is shown
- make Add Transaction page full width with minimal horizontal padding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851b6fd86a48333a85c0e51ff48b85f