### PR TITLE
Fix header navigation visibility during auth

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -26,7 +26,12 @@ const Header = ({ className, showNavigation = true, showBack = false }: HeaderPr
   const currentPageTitle = routeTitleMap[location.pathname] || 'Xpensia';
   const isLandingPage = location.pathname === '/';
   const isAuthPage = location.pathname === '/onboarding';
-  const shouldShowNavigation = showNavigation && !isAuthPage && !isLandingPage && auth.isAuthenticated;
+  // Show navigation when authenticated or while auth state is loading
+  const shouldShowNavigation =
+    showNavigation &&
+    !isAuthPage &&
+    !isLandingPage &&
+    (auth.isAuthenticated || auth.isLoading);
 
   if (isAuthPage) {
     return <AuthHeader className={className} />;


### PR DESCRIPTION
## Summary
- ensure dashboard settings and hamburger menu show while auth is loading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851c0d23d4c83339b036aa981495e96