### PR TITLE
Fix initial header visibility

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -26,12 +26,11 @@ const Header = ({ className, showNavigation = true, showBack = false }: HeaderPr
   const currentPageTitle = routeTitleMap[location.pathname] || 'Xpensia';
   const isLandingPage = location.pathname === '/';
   const isAuthPage = location.pathname === '/onboarding';
-  // Show navigation when authenticated or while auth state is loading
+  // Show navigation on all pages except landing and onboarding
   const shouldShowNavigation =
     showNavigation &&
     !isAuthPage &&
-    !isLandingPage &&
-    (auth.isAuthenticated || auth.isLoading);
+    !isLandingPage;
 
   if (isAuthPage) {
     return <AuthHeader className={className} />;


### PR DESCRIPTION
## Summary
- ensure header navigation shows even before authentication status is confirmed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851c4b8e8708333953b722a7ed7fe56