### PR TITLE
Use PageHeader in transactions page

### DIFF
--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import Layout from '@/components/Layout';
 import { motion } from 'framer-motion';
-import TransactionHeader from '@/components/transactions/TransactionHeader';
+import PageHeader from '@/components/layout/PageHeader';
 import TransactionsByDate from '@/components/transactions/TransactionsByDate';
 import EditTransactionDialog from '@/components/transactions/EditTransactionDialog';
 import MobileActions from '@/components/transactions/MobileActions';
@@ -62,42 +62,44 @@ const Transactions = () => {
   
   return (
     <Layout withPadding={false}>
-      <div className="sticky top-[var(--header-height)] z-10 bg-background/95 backdrop-blur-xl border-b">
-        <div className="px-[var(--page-padding-x)] py-2">
-          <div className="flex items-center justify-between mb-2">
-            <h1 className="text-xl font-bold">Transactions</h1>
-            <div className="flex items-center space-x-1.5">
-              {isMobile && (
-                <div className="border rounded-md p-0.5">
-                  <Button
-                    variant={viewMode === 'list' ? 'secondary' : 'ghost'}
-                    size="icon"
-                    className="h-7 w-7"
-                    onClick={() => setViewMode('list')}
-                  >
-                    <List className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button
-                    variant={viewMode === 'swipeable' ? 'secondary' : 'ghost'}
-                    size="icon"
-                    className="h-7 w-7"
-                    onClick={() => setViewMode('swipeable')}
-                  >
-                    <Grid className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              )}
-              <Button size="sm" onClick={() => navigate('/edit-transaction')}>
-                Add Transaction
-              </Button>
-            </div>
-          </div>
-          
-          {/* Search and Filters */}
-          <div className="flex flex-col sm:flex-row gap-2 items-center">
-            <div className="relative flex-1 w-full">
-              <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={16} />
-              <Input
+      <PageHeader
+        title="Transactions"
+        className="pt-2"
+        actions={(
+          <>
+            {isMobile && (
+              <div className="border rounded-md p-0.5">
+                <Button
+                  variant={viewMode === 'list' ? 'secondary' : 'ghost'}
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => setViewMode('list')}
+                >
+                  <List className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant={viewMode === 'swipeable' ? 'secondary' : 'ghost'}
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => setViewMode('swipeable')}
+                >
+                  <Grid className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            )}
+            <Button size="sm" onClick={() => navigate('/edit-transaction')}>
+              Add Transaction
+            </Button>
+          </>
+        )}
+      />
+
+      <div className="px-[var(--page-padding-x)] pt-2">
+        {/* Search and Filters */}
+        <div className="flex flex-col sm:flex-row gap-2 items-center">
+          <div className="relative flex-1 w-full">
+            <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={16} />
+            <Input
                 placeholder="Search transactions..."
                 className="pl-8 h-8 text-sm"
                 value={searchQuery}


### PR DESCRIPTION
## Summary
- replace custom header in Transactions page with reusable PageHeader component
- keep header actions within `actions` prop and adjust layout spacing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852e89813708333bfb7f5df35e85e29