### PR TITLE
Improve TransactionsByDate formatting

### DIFF
--- a/src/components/transactions/TransactionsByDate.tsx
+++ b/src/components/transactions/TransactionsByDate.tsx
@@ -31,7 +31,7 @@ const TransactionsByDate: React.FC<TransactionsByDateProps> = ({
 
   const formatDate = (dateString: string) => {
     try {
-      return format(parseISO(dateString), 'EEEE, MMMM d, yyyy');
+      return format(parseISO(dateString), 'EEE, MMM d');
     } catch (e) {
       // Fallback for any date parsing issues
       return dateString;
@@ -42,7 +42,7 @@ const TransactionsByDate: React.FC<TransactionsByDateProps> = ({
     <div className="space-y-6">
       {sortedDates.map(date => (
         <div key={date} className="space-y-2">
-          <h3 className="font-medium text-muted-foreground">
+          <h3 className="font-semibold text-gray-600 text-sm">
             {formatDate(date)}
           </h3>
           


### PR DESCRIPTION
## Summary
- adjust date format in TransactionsByDate
- make date headers bolder and gray

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852ef235d148333aee2023ed8f37208