### PR TITLE
Fix bottom padding for Transactions page

### DIFF
--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -143,7 +143,7 @@ const Transactions = () => {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        className="px-[var(--page-padding-x)] py-2 mt-1"
+        className="px-[var(--page-padding-x)] pt-2 pb-24 mt-1"
       >
         {filteredTransactions.length > 0 ? (
           isMobile && viewMode === 'swipeable' ? (


### PR DESCRIPTION
## Summary
- adjust bottom padding so the FAB doesn't hide the last transaction

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852f30d60ec8333b2e2f1dd18bf5bb6