### PR TITLE
Add time trend and net balance charts

### DIFF
--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { formatCurrency } from '@/lib/formatters';
+
+interface CategoryItem {
+  name: string;
+  value: number;
+}
+
+interface CategoryChartProps {
+  data: CategoryItem[];
+}
+
+const COLORS = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#6c757d'];
+const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 20 };
+
+const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
+  const limited = data.slice(0, 5);
+  const total = limited.reduce((sum, c) => sum + c.value, 0);
+  const hasData = limited.length > 0;
+
+  return (
+    <Card className="border border-border shadow-sm overflow-hidden">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-xl font-medium">By Category</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          limited.length > 1 ? (
+            <div className="h-[300px] w-full" role="img" aria-label="Expenses by category donut chart">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart margin={CHART_MARGIN}>
+                  <Pie
+                    data={limited}
+                    cx="50%"
+                    cy="50%"
+                    labelLine={false}
+                    outerRadius={80}
+                    innerRadius={40}
+                    fill="#8884d8"
+                    dataKey="value"
+                    isAnimationActive
+                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                  >
+                    {limited.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle" className="text-sm fill-foreground">
+                    {formatCurrency(total)}
+                  </text>
+                  <Tooltip formatter={(value) => formatCurrency(Math.abs(Number(value)))} />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <p className="text-center text-muted-foreground py-12">Not enough data to show a meaningful breakdown</p>
+          )
+        ) : (
+          <p className="text-center text-muted-foreground py-12">No data available yet. Try adding a few transactions first.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CategoryChart;

--- a/src/components/charts/NetBalanceChart.tsx
+++ b/src/components/charts/NetBalanceChart.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  ComposedChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  Line,
+  LabelList,
+  CartesianGrid
+} from 'recharts';
+import { TimePeriodData } from '@/types/transaction';
+import { formatCurrency } from '@/utils/format-utils';
+
+interface NetBalanceChartProps {
+  data: (TimePeriodData & { balance: number })[];
+}
+
+const NetBalanceChart: React.FC<NetBalanceChartProps> = ({ data }) => {
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('default', { month: 'short', day: '2-digit' });
+  };
+
+  return (
+    <div className="h-[270px] w-full">
+      {data.length === 0 ? (
+        <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+          No data available
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
+            <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+            <XAxis dataKey="date" tickFormatter={formatDate} tick={{ fontSize: 11 }} />
+            <YAxis tickFormatter={(v) => formatCurrency(v, 'USD').replace('.00', '')} width={45} tick={{ fontSize: 11 }} />
+            <Tooltip formatter={(value: number) => [formatCurrency(value), '']} labelFormatter={formatDate} />
+            <Legend wrapperStyle={{ fontSize: '11px', paddingTop: '5px' }} />
+            <Bar dataKey="income" name="Income" stackId="a" fill="#27AE60">
+              <LabelList dataKey="income" position="top" formatter={(v: number) => formatCurrency(v, 'USD')} />
+            </Bar>
+            <Bar dataKey="expense" name="Expenses" stackId="a" fill="#DC3545">
+              <LabelList dataKey="expense" position="top" formatter={(v: number) => formatCurrency(v, 'USD')} />
+            </Bar>
+            <Line type="monotone" dataKey="balance" name="Balance" stroke="#0d6efd" strokeWidth={2} dot={{ r: 2 }} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+};
+
+export default NetBalanceChart;

--- a/src/components/charts/SubcategoryChart.tsx
+++ b/src/components/charts/SubcategoryChart.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { formatCurrency } from '@/lib/formatters';
+
+interface Item {
+  name: string;
+  value: number;
+}
+
+interface SubcategoryChartProps {
+  data: Item[];
+}
+
+const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 20 };
+
+const BarTooltip = (total: number) => ({ active, payload }: any) => {
+  if (active && payload && payload.length) {
+    const { name, value } = payload[0].payload;
+    const percent = total ? ((value / total) * 100).toFixed(1) : null;
+    return (
+      <div className="bg-popover border border-border p-2 rounded-md shadow-sm text-sm">
+        <p className="font-medium">{name}</p>
+        <p className="text-primary">
+          {formatCurrency(Math.abs(value))}
+          {percent ? ` • ${percent}%` : ''}
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
+const YAxisTick = ({ x, y, payload }: any) => {
+  const text = String(payload.value);
+  const truncated = text.length > 10 ? `${text.slice(0, 10)}…` : text;
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <title>{text}</title>
+      <text x={-4} y={0} dy={4} textAnchor="end" className="text-xs fill-foreground">
+        {truncated}
+      </text>
+    </g>
+  );
+};
+
+const SubcategoryChart: React.FC<SubcategoryChartProps> = ({ data }) => {
+  const total = data.reduce((sum, c) => sum + c.value, 0);
+  const hasData = data.length > 0;
+
+  return (
+    <Card className="border border-border shadow-sm overflow-hidden">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-xl font-medium">Subcategories</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          <div className="h-[300px] w-full" role="img" aria-label="Expenses by subcategory bar chart">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data} layout="vertical" margin={CHART_MARGIN}>
+                <XAxis type="number" tickFormatter={(value) => formatCurrency(Math.abs(value)).replace(/[^0-9.]/g, '')} />
+                <YAxis type="category" dataKey="name" width={100} tick={YAxisTick} />
+                <Tooltip content={BarTooltip(total)} />
+                <Bar dataKey="value" fill="hsl(var(--primary))" radius={[4, 4, 4, 4]} isAnimationActive />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <p className="text-center text-muted-foreground py-12">No data available yet. Try adding a few transactions first.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SubcategoryChart;


### PR DESCRIPTION
## Summary
- create new chart components for category breakdowns and net balance
- show new timeline and balance charts in Dashboard
- add tabbed interface for Trends, Net Balance, By Category and Subcategories

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4a176e0833398d0f587d2a06610