### PR TITLE
Add time trend and net balance charts

### DIFF
--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { formatCurrency } from '@/lib/formatters';
+
+interface CategoryItem {
+  name: string;
+  value: number;
+}
+
+interface CategoryChartProps {
+  data: CategoryItem[];
+}
+
+const COLORS = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#6c757d'];
+const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 20 };
+
+const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
+  const limited = data.slice(0, 5);
+  const total = limited.reduce((sum, c) => sum + c.value, 0);
+  const hasData = limited.length > 0;
+
+  return (
+    <Card className="border border-border shadow-sm overflow-hidden">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-xl font-medium">By Category</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          limited.length > 1 ? (
+            <div className="h-[300px] w-full" role="img" aria-label="Expenses by category donut chart">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart margin={CHART_MARGIN}>
+                  <Pie
+                    data={limited}
+                    cx="50%"
+                    cy="50%"
+                    labelLine={false}
+                    outerRadius={80}
+                    innerRadius={40}
+                    fill="#8884d8"
+                    dataKey="value"
+                    isAnimationActive
+                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                  >
+                    {limited.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle" className="text-sm fill-foreground">
+                    {formatCurrency(total)}
+                  </text>
+                  <Tooltip formatter={(value) => formatCurrency(Math.abs(Number(value)))} />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <p className="text-center text-muted-foreground py-12">Not enough data to show a meaningful breakdown</p>
+          )
+        ) : (
+          <p className="text-center text-muted-foreground py-12">No data available yet. Try adding a few transactions first.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CategoryChart;

--- a/src/components/charts/NetBalanceChart.tsx
+++ b/src/components/charts/NetBalanceChart.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  ComposedChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  Line,
+  LabelList,
+  CartesianGrid
+} from 'recharts';
+import { TimePeriodData } from '@/types/transaction';
+import { formatCurrency } from '@/utils/format-utils';
+
+interface NetBalanceChartProps {
+  data: (TimePeriodData & { balance: number })[];
+}
+
+const NetBalanceChart: React.FC<NetBalanceChartProps> = ({ data }) => {
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('default', { month: 'short', day: '2-digit' });
+  };
+
+  return (
+    <div className="h-[270px] w-full">
+      {data.length === 0 ? (
+        <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+          No data available
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
+            <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+            <XAxis dataKey="date" tickFormatter={formatDate} tick={{ fontSize: 11 }} />
+            <YAxis tickFormatter={(v) => formatCurrency(v, 'USD').replace('.00', '')} width={45} tick={{ fontSize: 11 }} />
+            <Tooltip formatter={(value: number) => [formatCurrency(value), '']} labelFormatter={formatDate} />
+            <Legend wrapperStyle={{ fontSize: '11px', paddingTop: '5px' }} />
+            <Bar dataKey="income" name="Income" stackId="a" fill="#27AE60">
+              <LabelList dataKey="income" position="top" formatter={(v: number) => formatCurrency(v, 'USD')} />
+            </Bar>
+            <Bar dataKey="expense" name="Expenses" stackId="a" fill="#DC3545">
+              <LabelList dataKey="expense" position="top" formatter={(v: number) => formatCurrency(v, 'USD')} />
+            </Bar>
+            <Line type="monotone" dataKey="balance" name="Balance" stroke="#0d6efd" strokeWidth={2} dot={{ r: 2 }} />
+          </ComposedChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+};
+
+export default NetBalanceChart;

--- a/src/components/charts/SubcategoryChart.tsx
+++ b/src/components/charts/SubcategoryChart.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { formatCurrency } from '@/lib/formatters';
+
+interface Item {
+  name: string;
+  value: number;
+}
+
+interface SubcategoryChartProps {
+  data: Item[];
+}
+
+const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 20 };
+
+const BarTooltip = (total: number) => ({ active, payload }: any) => {
+  if (active && payload && payload.length) {
+    const { name, value } = payload[0].payload;
+    const percent = total ? ((value / total) * 100).toFixed(1) : null;
+    return (
+      <div className="bg-popover border border-border p-2 rounded-md shadow-sm text-sm">
+        <p className="font-medium">{name}</p>
+        <p className="text-primary">
+          {formatCurrency(Math.abs(value))}
+          {percent ? ` • ${percent}%` : ''}
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
+const YAxisTick = ({ x, y, payload }: any) => {
+  const text = String(payload.value);
+  const truncated = text.length > 10 ? `${text.slice(0, 10)}…` : text;
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <title>{text}</title>
+      <text x={-4} y={0} dy={4} textAnchor="end" className="text-xs fill-foreground">
+        {truncated}
+      </text>
+    </g>
+  );
+};
+
+const SubcategoryChart: React.FC<SubcategoryChartProps> = ({ data }) => {
+  const total = data.reduce((sum, c) => sum + c.value, 0);
+  const hasData = data.length > 0;
+
+  return (
+    <Card className="border border-border shadow-sm overflow-hidden">
+      <CardHeader className="pb-0">
+        <CardTitle className="text-xl font-medium">Subcategories</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          <div className="h-[300px] w-full" role="img" aria-label="Expenses by subcategory bar chart">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data} layout="vertical" margin={CHART_MARGIN}>
+                <XAxis type="number" tickFormatter={(value) => formatCurrency(Math.abs(value)).replace(/[^0-9.]/g, '')} />
+                <YAxis type="category" dataKey="name" width={100} tick={YAxisTick} />
+                <Tooltip content={BarTooltip(total)} />
+                <Bar dataKey="value" fill="hsl(var(--primary))" radius={[4, 4, 4, 4]} isAnimationActive />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <p className="text-center text-muted-foreground py-12">No data available yet. Try adding a few transactions first.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SubcategoryChart;

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,88 +1,312 @@
-
-import React, { useState, useEffect } from 'react';
-import { motion } from 'framer-motion';
+import React from 'react';
 import Layout from '@/components/Layout';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { INITIAL_TRANSACTIONS } from '@/lib/mock-data';
-import { Transaction } from '@/types/transaction';
+import PageHeader from '@/components/layout/PageHeader';
+import { useTransactions } from '@/context/TransactionContext';
+import {
+  ToggleGroup,
+  ToggleGroupItem
+} from '@/components/ui/toggle-group';
+import { DatePicker } from '@/components/ui/date-picker';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid
+} from 'recharts';
 import { AnalyticsService } from '@/services/AnalyticsService';
-import { CHART_COLORS } from '@/constants/analytics';
+import { transactionService } from '@/services/TransactionService';
+import { formatCurrency } from '@/lib/formatters';
+import { toast } from '@/components/ui/use-toast';
 
-// Component imports
-import SummaryCards from '@/components/analytics/SummaryCards';
-import TopSpendingCategories from '@/components/analytics/TopSpendingCategories';
-import CategoryPieChart from '@/components/analytics/CategoryPieChart';
-import CategoryBreakdown from '@/components/analytics/CategoryBreakdown';
-import MonthlyTrendsChart from '@/components/analytics/MonthlyTrendsChart';
+const tips = [
+  'Review your subscriptions regularly to avoid surprises.',
+  'Small daily savings add up over time.',
+  'Use categories to see where your money goes most.'
+];
 
-const Analytics = () => {
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [activeTab, setActiveTab] = useState('overview');
+const Analytics: React.FC = () => {
+  const { transactions } = useTransactions();
 
-  useEffect(() => {
-    // Load transactions from localStorage or use initial data
-    const storedTransactions = localStorage.getItem('transactions');
-    if (storedTransactions) {
-      setTransactions(JSON.parse(storedTransactions));
-    } else {
-      setTransactions(INITIAL_TRANSACTIONS as Transaction[]);
+  type Range = '' | 'day' | 'week' | 'month' | 'year' | 'custom';
+  const [range, setRange] = React.useState<Range>('month');
+  const [customStart, setCustomStart] = React.useState<Date | null>(null);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+
+  const filteredTransactions = React.useMemo(() => {
+    if (!range) return transactions;
+
+    const now = new Date();
+    let start = new Date(now);
+    let end = new Date(now);
+
+    switch (range) {
+      case 'day':
+        start.setHours(0, 0, 0, 0);
+        break;
+      case 'week':
+        start.setDate(now.getDate() - 6);
+        start.setHours(0, 0, 0, 0);
+        break;
+      case 'month':
+        start = new Date(now.getFullYear(), now.getMonth(), 1);
+        break;
+      case 'year':
+        start = new Date(now.getFullYear(), 0, 1);
+        break;
+      case 'custom':
+        if (customStart) start = new Date(customStart);
+        if (customEnd) end = new Date(customEnd);
+        break;
     }
-  }, []);
 
-  // Compute all analytics data
-  const totals = AnalyticsService.getTotals(transactions);
-  const categoryData = AnalyticsService.getCategoryData(transactions);
-  const monthlyData = AnalyticsService.getMonthlyData(transactions);
-  const uniqueCategories = AnalyticsService.getUniqueCategories(transactions);
-  const topCategories = AnalyticsService.getTopCategories(categoryData, 3);
+    const toDate = range === 'custom' ? end : now;
+
+    return transactions.filter(t => {
+      const d = new Date(t.date);
+      return d >= start && d <= toDate;
+    });
+  }, [transactions, range, customStart, customEnd]);
+
+  const budgetData = React.useMemo(() => {
+    const categories = transactionService.getCategories().filter(c => c.metadata?.budget);
+    return categories.map(cat => {
+      const spent = filteredTransactions
+        .filter(t => t.category === cat.name && t.amount < 0)
+        .reduce((sum, t) => sum + Math.abs(t.amount), 0);
+      const budget = cat.metadata?.budget || 0;
+      const percentUsed = budget ? (spent / budget) * 100 : 0;
+      return {
+        name: cat.name,
+        budget,
+        spent,
+        percentUsed
+      };
+    });
+  }, [filteredTransactions]);
+
+  const topCategories = React.useMemo(() => {
+    return AnalyticsService.getCategoryData(filteredTransactions).slice(0, 5);
+  }, [filteredTransactions]);
+
+  const monthlyBalance = React.useMemo(() => {
+    const grouped: Record<string, { income: number; expense: number }> = {};
+    filteredTransactions.forEach(tx => {
+      const d = new Date(tx.date);
+      const key = `${d.getFullYear()}-${d.getMonth()}`;
+      if (!grouped[key]) grouped[key] = { income: 0, expense: 0 };
+      if (tx.amount >= 0) {
+        grouped[key].income += tx.amount;
+      } else {
+        grouped[key].expense += Math.abs(tx.amount);
+      }
+    });
+    return Object.entries(grouped)
+      .sort((a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime())
+      .map(([key, val]) => {
+        const [year, month] = key.split('-').map(Number);
+        const date = new Date(year, month, 1);
+        return {
+          date: date.toISOString(),
+          balance: val.income - val.expense
+        };
+      });
+  }, [filteredTransactions]);
+
+  const uncategorizedCount = React.useMemo(
+    () => filteredTransactions.filter(t => !t.category || t.category === 'Uncategorized').length,
+    [filteredTransactions]
+  );
+
+  const randomTip = React.useMemo(() => tips[Math.floor(Math.random() * tips.length)], []);
+
+  const handleExport = () => {
+    const data = localStorage.getItem('transactions');
+    if (!data) {
+      toast({ title: 'No data to export' });
+      return;
+    }
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'transactions.json';
+    a.click();
+    URL.revokeObjectURL(url);
+    toast({ title: 'Exported transactions' });
+  };
 
   return (
-    <Layout>
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5 }}
-        className="space-y-6"
-      >
-        <h1 className="text-3xl font-bold tracking-tight">Analytics</h1>
-        
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="mb-6">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="categories">Categories</TabsTrigger>
-            <TabsTrigger value="trends">Monthly Trends</TabsTrigger>
-          </TabsList>
-          
-          <TabsContent value="overview" className="space-y-6">
-            <SummaryCards totals={totals} />
-            
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <TopSpendingCategories 
-                categories={topCategories} 
-                totalExpenses={totals.expenses} 
-                colors={CHART_COLORS} 
-              />
-              
-              <CategoryPieChart 
-                categoryData={categoryData} 
-                colors={CHART_COLORS} 
-              />
+    <Layout withPadding={false} fullWidth>
+      <div className="px-1">
+        <PageHeader title="Analytics" />
+
+        <div className="my-2">
+          <ToggleGroup
+            type="single"
+            value={range}
+            onValueChange={val => setRange(val as Range)}
+            className="w-full bg-muted p-1 text-muted-foreground rounded-md"
+          >
+            {['day', 'week', 'month', 'year'].map(r => (
+              <ToggleGroupItem
+                key={r}
+                value={r}
+                className="flex-1 transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
+              >
+                {r.charAt(0).toUpperCase() + r.slice(1)}
+              </ToggleGroupItem>
+            ))}
+            <ToggleGroupItem
+              value="custom"
+              className="flex-1 transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
+            >
+              Custom
+            </ToggleGroupItem>
+          </ToggleGroup>
+          {range === 'custom' && (
+            <div className="mt-2 flex items-center gap-2 animate-in fade-in">
+              <DatePicker date={customStart} setDate={setCustomStart} placeholder="Start" />
+              <DatePicker date={customEnd} setDate={setCustomEnd} placeholder="End" />
             </div>
-          </TabsContent>
-          
-          <TabsContent value="categories">
-            <CategoryBreakdown 
-              categories={uniqueCategories} 
-              categoryData={categoryData} 
-              totalExpenses={totals.expenses} 
-            />
-          </TabsContent>
-          
-          <TabsContent value="trends">
-            <MonthlyTrendsChart monthlyData={monthlyData} />
-          </TabsContent>
-        </Tabs>
-      </motion.div>
+          )}
+        </div>
+
+        <div className="space-y-4 pb-20">
+          <Card>
+            <CardHeader>
+              <CardTitle>Budget vs Actual</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {budgetData.length ? (
+                <div className="space-y-3">
+                  {budgetData.map(b => (
+                    <div key={b.name} className="space-y-1">
+                      <div className="flex justify-between text-sm">
+                        <span>{b.name}</span>
+                        <span>{formatCurrency(b.spent)} / {formatCurrency(b.budget)}</span>
+                      </div>
+                      <Progress value={Math.min(100, b.percentUsed)} className="h-2" />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground text-center py-6">No budget data configured.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Top Expense Categories</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {topCategories.length ? (
+                <div className="h-60">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={topCategories} margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
+                      <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                      <YAxis tickFormatter={v => formatCurrency(v).replace(/[^0-9.]/g, '')} width={40} tick={{ fontSize: 11 }} />
+                      <Tooltip formatter={(v:number)=>formatCurrency(Number(v))} />
+                      <Bar dataKey="value" fill="hsl(var(--primary))" radius={[4,4,0,0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground text-center py-6">No expense data.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Net Monthly Balance</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {monthlyBalance.length ? (
+                <div className="h-48">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={monthlyBalance} margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
+                      <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                      <XAxis dataKey="date" tickFormatter={d=>new Date(d).toLocaleDateString('default',{month:'short'})} tick={{fontSize:11}} />
+                      <YAxis tickFormatter={v => formatCurrency(v).replace(/[^0-9.]/g,'')} width={40} tick={{fontSize:11}} />
+                      <Tooltip formatter={(v:number)=>formatCurrency(Number(v))} labelFormatter={d=>new Date(d).toLocaleDateString('default',{month:'short',year:'2-digit'})} />
+                      <Line type="monotone" dataKey="balance" stroke="hsl(var(--primary))" strokeWidth={2} dot={{r:2}} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground text-center py-6">No data for this range.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Goal Progress Tracker</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground text-center py-6">No goals configured.</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recurring Transactions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground text-center py-6">Recurring transaction insights coming soon.</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Uncategorized Transactions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {uncategorizedCount > 0 ? (
+                <p className="text-sm text-muted-foreground">You have {uncategorizedCount} uncategorized transactions.</p>
+              ) : (
+                <p className="text-sm text-muted-foreground">All transactions are categorized.</p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Smart Tip</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm">{randomTip}</p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Export Report</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <button
+                onClick={handleExport}
+                className="text-sm text-primary underline"
+              >
+                Download transactions JSON
+              </button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary
- create new chart components for category breakdowns and net balance
- show new timeline and balance charts in Dashboard
- add tabbed interface for Trends, Net Balance, By Category and Subcategories
- revamp Analytics page into vertical insight cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f4a176e0833398d0f587d2a06610