### PR TITLE
Remove unused tip prop from AvatarGreeting

### DIFF
--- a/src/components/dashboard/AvatarGreeting.tsx
+++ b/src/components/dashboard/AvatarGreeting.tsx
@@ -4,10 +4,9 @@ import { User } from '@/types/user';
 
 interface AvatarGreetingProps {
   user: User | null;
-  tip?: string;
 }
 
-export const AvatarGreeting: React.FC<AvatarGreetingProps> = ({ user, tip }) => {
+export const AvatarGreeting: React.FC<AvatarGreetingProps> = ({ user }) => {
   const firstName = user?.fullName?.split(' ')[0] || 'there';
   const avatar = user?.avatar;
   const hour = new Date().getHours();
@@ -22,7 +21,6 @@ export const AvatarGreeting: React.FC<AvatarGreetingProps> = ({ user, tip }) => 
       </Avatar>
       <span className="flex flex-col leading-tight">
         <span>{`${greeting}, ${firstName}`}</span>
-        {tip && <span className="text-xs text-muted-foreground">{tip}</span>}
       </span>
     </span>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -46,7 +46,6 @@ const Dashboard = () => {
   const { user } = useUser();
   const navigate = useNavigate();
 
-  const tip = 'Remember to log your expenses today';
 
   type Range = '' | 'day' | 'week' | 'month' | 'year' | 'custom';
   const [range, setRange] = React.useState<Range>('');
@@ -203,7 +202,7 @@ const Dashboard = () => {
     <Layout withPadding={false} fullWidth>
       <div className="px-1">
         <PageHeader
-          title={<AvatarGreeting user={user} tip={tip} />}
+          title={<AvatarGreeting user={user} />}
         />
 
         <div className="my-2">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -46,7 +46,6 @@ const Home = () => {
   const { user } = useUser();
   const navigate = useNavigate();
 
-  const tip = 'Remember to log your expenses today';
 
   type Range = '' | 'day' | 'week' | 'month' | 'year' | 'custom';
   const [range, setRange] = React.useState<Range>('');
@@ -203,7 +202,7 @@ const Home = () => {
     <Layout withPadding={false} fullWidth>
       <div className="px-1">
         <PageHeader
-          title={<AvatarGreeting user={user} tip={tip} />}
+          title={<AvatarGreeting user={user} />}
         />
 
         <div className="my-2">


### PR DESCRIPTION
## Summary
- simplify `AvatarGreeting` component and props
- stop passing and declaring `tip` value in dashboard and home pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6853e9bf368083339a170135c21623e0