### PR TITLE
Add color palette for bar charts

### DIFF
--- a/src/components/ExpenseChart.tsx
+++ b/src/components/ExpenseChart.tsx
@@ -170,7 +170,11 @@ const ExpenseChart = ({ expensesByCategory = [], expensesBySubcategory = [] }: E
                       <XAxis type="number" tickFormatter={(value) => formatCurrency(Math.abs(value)).replace(/[^0-9.]/g, '')} />
                       <YAxis type="category" dataKey="name" width={100} tick={YAxisTick} />
                       <Tooltip content={BarTooltip(totalSubcategory)} />
-                      <Bar dataKey="value" fill="hsl(var(--primary))" radius={[4, 4, 4, 4]} isAnimationActive />
+                      <Bar dataKey="value" radius={[4, 4, 4, 4]} isAnimationActive>
+                        {expensesBySubcategory.map((_, index) => (
+                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Bar>
                     </BarChart>
                   </ResponsiveContainer>
                 </div>

--- a/src/components/analytics/MonthlyTrendsChart.tsx
+++ b/src/components/analytics/MonthlyTrendsChart.tsx
@@ -1,13 +1,15 @@
 
 import React from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, Cell } from 'recharts';
 import { formatCurrency } from '@/lib/formatters';
 import { MonthlyData } from '@/services/AnalyticsService';
 
 interface MonthlyTrendsChartProps {
   monthlyData: MonthlyData[];
 }
+
+const COLORS = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#6c757d'];
 
 const MonthlyTrendsChart = ({ monthlyData }: MonthlyTrendsChartProps) => {
   // Custom tooltip for the chart
@@ -41,7 +43,11 @@ const MonthlyTrendsChart = ({ monthlyData }: MonthlyTrendsChartProps) => {
                 />
                 <Tooltip content={<CustomTooltip />} />
                 <Legend wrapperStyle={{fontSize: '12px'}} />
-                <Bar dataKey="total" name="Spending" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+                <Bar dataKey="total" name="Spending" radius={[4, 4, 0, 0]}>
+                  {monthlyData.map((_, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Bar>
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/src/components/charts/SubcategoryChart.tsx
+++ b/src/components/charts/SubcategoryChart.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { formatCurrency } from '@/lib/formatters';
 
 interface Item {
@@ -13,6 +13,7 @@ interface SubcategoryChartProps {
 }
 
 const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 20 };
+const COLORS = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#6c757d'];
 
 const BarTooltip = (total: number) => ({ active, payload }: any) => {
   if (active && payload && payload.length) {
@@ -61,7 +62,11 @@ const SubcategoryChart: React.FC<SubcategoryChartProps> = ({ data }) => {
                 <XAxis type="number" tickFormatter={(value) => formatCurrency(Math.abs(value)).replace(/[^0-9.]/g, '')} />
                 <YAxis type="category" dataKey="name" width={100} tick={YAxisTick} />
                 <Tooltip content={BarTooltip(total)} />
-                <Bar dataKey="value" fill="hsl(var(--primary))" radius={[4, 4, 4, 4]} isAnimationActive />
+                <Bar dataKey="value" radius={[4, 4, 4, 4]} isAnimationActive>
+                  {data.map((_, index) => (
+                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Bar>
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -23,12 +23,15 @@ import {
   ResponsiveContainer,
   LineChart,
   Line,
-  CartesianGrid
+  CartesianGrid,
+  Cell
 } from 'recharts';
 import { AnalyticsService } from '@/services/AnalyticsService';
 import { transactionService } from '@/services/TransactionService';
 import { formatCurrency } from '@/lib/formatters';
 import { toast } from '@/components/ui/use-toast';
+
+const COLORS = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#6c757d'];
 
 const tips = [
   'Review your subscriptions regularly to avoid surprises.',
@@ -219,7 +222,11 @@ const Analytics: React.FC = () => {
                       <XAxis dataKey="name" tick={{ fontSize: 11 }} />
                       <YAxis tickFormatter={v => formatCurrency(v).replace(/[^0-9.]/g, '')} width={40} tick={{ fontSize: 11 }} />
                       <Tooltip formatter={(v:number)=>formatCurrency(Number(v))} />
-                      <Bar dataKey="value" fill="hsl(var(--primary))" radius={[4,4,0,0]} />
+                      <Bar dataKey="value" radius={[4,4,0,0]}>
+                        {topCategories.map((_, index) => (
+                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Bar>
                     </BarChart>
                   </ResponsiveContainer>
                 </div>


### PR DESCRIPTION
## Summary
- add COLOR palette arrays
- map each bar to a color with `<Cell>` in monthly trends, expense, subcategory and top categories charts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68544ed001b08333a7cf8638740b14d1