### PR TITLE
Home page chart polish

### DIFF
--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { formatCurrency } from '@/lib/formatters';
+import { CHART_COLORS } from '@/constants/analytics';
 
 interface CategoryItem {
   name: string;
@@ -12,8 +13,7 @@ interface CategoryChartProps {
   data: CategoryItem[];
 }
 
-const COLORS = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#6c757d'];
-const CHART_MARGIN = { top: 20, right: 120, left: 20, bottom: 20 };
+const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 40 };
 
 const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
   const limited = data.slice(0, 5);
@@ -45,17 +45,17 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
                     fill="#8884d8"
                     dataKey="value"
                     isAnimationActive
-                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                    label={({ percent }) => `${(percent * 100).toFixed(0)}%`}
                   >
                     {limited.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
                     ))}
                   </Pie>
                   <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle" className="text-sm fill-foreground">
                     {formatCurrency(total)}
                   </text>
                   <Tooltip formatter={(value) => formatCurrency(Math.abs(Number(value)))} />
-                  <Legend layout="vertical" align="right" verticalAlign="middle" />
+                  <Legend layout="horizontal" align="center" verticalAlign="bottom" />
                 </PieChart>
               </ResponsiveContainer>
             </div>

--- a/src/components/charts/NetBalanceChart.tsx
+++ b/src/components/charts/NetBalanceChart.tsx
@@ -32,17 +32,17 @@ const NetBalanceChart: React.FC<NetBalanceChartProps> = ({ data }) => {
         </div>
       ) : (
         <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 10 }}>
+          <ComposedChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 20 }}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
             <XAxis dataKey="date" tickFormatter={formatDate} tick={{ fontSize: 11 }} />
-            <YAxis tickFormatter={(v) => formatCurrency(v, 'USD').replace('.00', '')} width={45} tick={{ fontSize: 11 }} />
+            <YAxis tickFormatter={(v) => formatCurrency(v, 'USD').replace('.00', '')} width={60} tick={{ fontSize: 12 }} />
             <Tooltip formatter={(value: number) => [formatCurrency(value), '']} labelFormatter={formatDate} />
             <Legend wrapperStyle={{ fontSize: '11px', paddingTop: '5px' }} />
             <Bar dataKey="income" name="Income" stackId="a" fill="#27AE60">
-              <LabelList dataKey="income" position="top" formatter={(v: number) => formatCurrency(v, 'USD')} />
+              <LabelList dataKey="income" position="top" formatter={(v: number) => formatCurrency(v, 'USD').replace('.00','')} style={{ fontSize: 10 }} />
             </Bar>
             <Bar dataKey="expense" name="Expenses" stackId="a" fill="#DC3545">
-              <LabelList dataKey="expense" position="top" formatter={(v: number) => formatCurrency(v, 'USD')} />
+              <LabelList dataKey="expense" position="top" formatter={(v: number) => formatCurrency(v, 'USD').replace('.00','')} style={{ fontSize: 10 }} />
             </Bar>
             <Line type="monotone" dataKey="balance" name="Balance" stroke="#0d6efd" strokeWidth={2} dot={{ r: 2 }} />
           </ComposedChart>

--- a/src/components/charts/SubcategoryChart.tsx
+++ b/src/components/charts/SubcategoryChart.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { formatCurrency } from '@/lib/formatters';
+import { CHART_COLORS } from '@/constants/analytics';
 
 interface Item {
   name: string;
@@ -13,7 +14,6 @@ interface SubcategoryChartProps {
 }
 
 const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 20 };
-const COLORS = ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1', '#6c757d'];
 
 const BarTooltip = (total: number) => ({ active, payload }: any) => {
   if (active && payload && payload.length) {
@@ -64,7 +64,7 @@ const SubcategoryChart: React.FC<SubcategoryChartProps> = ({ data }) => {
                 <Tooltip content={BarTooltip(total)} />
                 <Bar dataKey="value" radius={[4, 4, 4, 4]} isAnimationActive>
                   {data.map((_, index) => (
-                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
                   ))}
                 </Bar>
               </BarChart>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -137,23 +137,23 @@ const Dashboard = () => {
     }, {} as Record<string, number>);
 
   const iconMap: Record<string, JSX.Element> = {
-    Bills: <Receipt className="w-5 h-5" />,
-    Education: <GraduationCap className="w-5 h-5" />,
-    Entertainment: <Gamepad2 className="w-5 h-5" />,
-    Food: <Utensils className="w-5 h-5" />,
-    'Gifts & Donations': <Gift className="w-5 h-5" />,
-    Health: <HeartPulse className="w-5 h-5" />,
-    Housing: <Home className="w-5 h-5" />,
-    Kids: <Baby className="w-5 h-5" />,
-    'Personal Care': <Bath className="w-5 h-5" />,
-    Services: <ConciergeBell className="w-5 h-5" />,
-    Shopping: <ShoppingBag className="w-5 h-5" />,
-    Transfer: <ArrowLeftRight className="w-5 h-5" />,
-    Transportation: <Car className="w-5 h-5" />,
-    Travel: <Plane className="w-5 h-5" />,
-    Utilities: <Lightbulb className="w-5 h-5" />,
-    Income: <CircleDollarSign className="w-5 h-5" />,
-    Other: <Package className="w-5 h-5" />,
+    Bills: <Receipt className="w-6 h-6" />,
+    Education: <GraduationCap className="w-6 h-6" />,
+    Entertainment: <Gamepad2 className="w-6 h-6" />,
+    Food: <Utensils className="w-6 h-6" />,
+    'Gifts & Donations': <Gift className="w-6 h-6" />,
+    Health: <HeartPulse className="w-6 h-6" />,
+    Housing: <Home className="w-6 h-6" />,
+    Kids: <Baby className="w-6 h-6" />,
+    'Personal Care': <Bath className="w-6 h-6" />,
+    Services: <ConciergeBell className="w-6 h-6" />,
+    Shopping: <ShoppingBag className="w-6 h-6" />,
+    Transfer: <ArrowLeftRight className="w-6 h-6" />,
+    Transportation: <Car className="w-6 h-6" />,
+    Travel: <Plane className="w-6 h-6" />,
+    Utilities: <Lightbulb className="w-6 h-6" />,
+    Income: <CircleDollarSign className="w-6 h-6" />,
+    Other: <Package className="w-6 h-6" />,
   };
 
   const formatDisplayTitle = (txn: Transaction) => {
@@ -283,23 +283,25 @@ const Dashboard = () => {
                       key={transaction.id || idx}
                       onClick={() => navigate(`/edit-transaction/${transaction.id}`)}
                       aria-label="Edit transaction"
-                      className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 hover:shadow-md hover:bg-gray-50 transition-all cursor-pointer flex items-center justify-between gap-3"
+                      className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 hover:shadow-md hover:bg-gray-50 transition-all cursor-pointer"
                     >
-                      <div className="flex items-center gap-2 flex-1 min-w-0">
-                        {iconMap[transaction.category] || iconMap['Other']}
-                        <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          {iconMap[transaction.category] || iconMap['Other']}
+                          <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
+                        </div>
+                        <div
+                          className={transaction.amount < 0 ? 'text-red-600 font-semibold' : 'text-green-600 font-semibold'}
+                        >
+                          {transaction.amount < 0 ? '−' : '+'}
+                          {Math.abs(transaction.amount).toLocaleString(undefined, {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })}
+                        </div>
                       </div>
-                      <div className="text-xs text-muted-foreground flex-1 text-center whitespace-nowrap">
+                      <div className="text-xs text-muted-foreground mt-1">
                         {formatTxnDate(transaction.date)} • {transaction.category}
-                      </div>
-                      <div
-                        className={transaction.amount < 0 ? 'text-red-600 font-semibold' : 'text-green-600 font-semibold'}
-                      >
-                        {transaction.amount < 0 ? '−' : '+'}
-                        {Math.abs(transaction.amount).toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
                       </div>
                     </div>
                   ))}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,9 +48,16 @@ const Home = () => {
 
 
   type Range = '' | 'day' | 'week' | 'month' | 'year' | 'custom';
-  const [range, setRange] = React.useState<Range>('');
-  const [customStart, setCustomStart] = React.useState<Date | null>(null);
-  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+  const defaultEnd = React.useMemo(() => new Date(), []);
+  const defaultStart = React.useMemo(() => {
+    const d = new Date();
+    d.setMonth(d.getMonth() - 1);
+    return d;
+  }, []);
+
+  const [range, setRange] = React.useState<Range>('custom');
+  const [customStart, setCustomStart] = React.useState<Date | null>(defaultStart);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(defaultEnd);
   const [activeTab, setActiveTab] = React.useState('trends');
 
 
@@ -137,23 +144,23 @@ const Home = () => {
     }, {} as Record<string, number>);
 
   const iconMap: Record<string, JSX.Element> = {
-    Bills: <Receipt className="w-5 h-5" />,
-    Education: <GraduationCap className="w-5 h-5" />,
-    Entertainment: <Gamepad2 className="w-5 h-5" />,
-    Food: <Utensils className="w-5 h-5" />,
-    'Gifts & Donations': <Gift className="w-5 h-5" />,
-    Health: <HeartPulse className="w-5 h-5" />,
-    Housing: <Home className="w-5 h-5" />,
-    Kids: <Baby className="w-5 h-5" />,
-    'Personal Care': <Bath className="w-5 h-5" />,
-    Services: <ConciergeBell className="w-5 h-5" />,
-    Shopping: <ShoppingBag className="w-5 h-5" />,
-    Transfer: <ArrowLeftRight className="w-5 h-5" />,
-    Transportation: <Car className="w-5 h-5" />,
-    Travel: <Plane className="w-5 h-5" />,
-    Utilities: <Lightbulb className="w-5 h-5" />,
-    Income: <CircleDollarSign className="w-5 h-5" />,
-    Other: <Package className="w-5 h-5" />,
+    Bills: <Receipt className="w-6 h-6" />,
+    Education: <GraduationCap className="w-6 h-6" />,
+    Entertainment: <Gamepad2 className="w-6 h-6" />,
+    Food: <Utensils className="w-6 h-6" />,
+    'Gifts & Donations': <Gift className="w-6 h-6" />,
+    Health: <HeartPulse className="w-6 h-6" />,
+    Housing: <Home className="w-6 h-6" />,
+    Kids: <Baby className="w-6 h-6" />,
+    'Personal Care': <Bath className="w-6 h-6" />,
+    Services: <ConciergeBell className="w-6 h-6" />,
+    Shopping: <ShoppingBag className="w-6 h-6" />,
+    Transfer: <ArrowLeftRight className="w-6 h-6" />,
+    Transportation: <Car className="w-6 h-6" />,
+    Travel: <Plane className="w-6 h-6" />,
+    Utilities: <Lightbulb className="w-6 h-6" />,
+    Income: <CircleDollarSign className="w-6 h-6" />,
+    Other: <Package className="w-6 h-6" />,
   };
 
   const formatDisplayTitle = (txn: Transaction) => {
@@ -283,23 +290,25 @@ const Home = () => {
                       key={transaction.id || idx}
                       onClick={() => navigate(`/edit-transaction/${transaction.id}`)}
                       aria-label="Edit transaction"
-                      className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 hover:shadow-md hover:bg-gray-50 transition-all cursor-pointer flex items-center justify-between gap-3"
+                      className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 hover:shadow-md hover:bg-gray-50 transition-all cursor-pointer"
                     >
-                      <div className="flex items-center gap-2 flex-1 min-w-0">
-                        {iconMap[transaction.category] || iconMap['Other']}
-                        <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          {iconMap[transaction.category] || iconMap['Other']}
+                          <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
+                        </div>
+                        <div
+                          className={transaction.amount < 0 ? 'text-red-600 font-semibold' : 'text-green-600 font-semibold'}
+                        >
+                          {transaction.amount < 0 ? '−' : '+'}
+                          {Math.abs(transaction.amount).toLocaleString(undefined, {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                          })}
+                        </div>
                       </div>
-                      <div className="text-xs text-muted-foreground flex-1 text-center whitespace-nowrap">
+                      <div className="text-xs text-muted-foreground mt-1">
                         {formatTxnDate(transaction.date)} • {transaction.category}
-                      </div>
-                      <div
-                        className={transaction.amount < 0 ? 'text-red-600 font-semibold' : 'text-green-600 font-semibold'}
-                      >
-                        {transaction.amount < 0 ? '−' : '+'}
-                        {Math.abs(transaction.amount).toLocaleString(undefined, {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
## Summary
- default to custom date range for last month on Home page
- enlarge recent transaction icons
- display recent transactions on two lines
- clean up category and subcategory charts
- improve Net Balance chart readability

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854554570c483339d1e8de66d43783a