### PR TITLE
Fix custom date range alignment and header title

### DIFF
--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -1,8 +1,8 @@
 
 // Map routes to their corresponding titles
 export const routeTitleMap: Record<string, string> = {
-  '/': 'Home',
-  '/home': 'Home',
+  '/': 'Xpensia',
+  '/home': 'Xpensia',
   '/transactions': 'Transactions',
   '/analytics': 'Analytics',
   '/process-sms': 'Process SMS',

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -236,7 +236,7 @@ const Home = () => {
             </ToggleGroupItem>
           </ToggleGroup>
           {range === 'custom' && (
-            <div className="mt-2 flex items-center gap-2 animate-in fade-in">
+            <div className="mt-2 flex items-center justify-center gap-2 animate-in fade-in">
               <DatePicker date={customStart} setDate={setCustomStart} placeholder="Start" />
               <DatePicker date={customEnd} setDate={setCustomEnd} placeholder="End" />
             </div>


### PR DESCRIPTION
## Summary
- center custom date range pickers on Home page
- keep header title as "Xpensia" when navigating home

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685458c276f08333acdd2cda2446d11e