### PR TITLE
Fix category chart centering

### DIFF
--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -44,7 +44,9 @@ interface CategoryChartProps {
   data: CategoryItem[];
 }
 
-const CHART_MARGIN = { top: 20, right: 20, left: 20, bottom: 40 };
+// Extra bottom spacing is required for the legend, so we provide an equal
+// top margin to keep the donut vertically centered within the chart.
+const CHART_MARGIN = { top: 40, right: 20, left: 20, bottom: 40 };
 
 const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
   const limited = data.slice(0, 5);


### PR DESCRIPTION
## Summary
- balance margin around donut chart

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run dev` *(fails: parse error in unrelated file)*

------
https://chatgpt.com/codex/tasks/task_e_68545acaf09c83339cb121f6e1893c51