### PR TITLE
Add transfer fields and tweak transaction pages

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -79,6 +79,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
         title: transaction.title?.trim() || generateDefaultTitle(transaction),
         date: displayDate,
         description: transaction.description?.trim() || rawMessage,
+        toAccount: transaction.toAccount || '',
       };
     }
 
@@ -91,6 +92,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
       subcategory: 'none',
       date: new Date().toISOString().split('T')[0],
       fromAccount: 'Cash',
+      toAccount: '',
       currency: 'SAR',
       description: '',
       notes: '',
@@ -102,7 +104,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
     if (transaction) {
       const driven: Partial<Record<keyof Transaction, boolean>> = {};
       if (transaction.source === 'smart-paste' || transaction.details?.rawMessage) {
-        ['type', 'title', 'amount', 'currency', 'vendor', 'fromAccount', 'date', 'category', 'subcategory'].forEach((field) => {
+        ['type', 'title', 'amount', 'currency', 'vendor', 'fromAccount', 'toAccount', 'date', 'category', 'subcategory'].forEach((field) => {
           const value = transaction[field as keyof Transaction];
           const isDriven =
             value != null &&
@@ -134,6 +136,9 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
       if (field === 'type') {
         updated.category = 'Uncategorized';
         updated.subcategory = 'none';
+        if (value !== 'transfer') {
+          updated.toAccount = '';
+        }
       }
 
       if (field === 'category') {
@@ -183,7 +188,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
   const inputPadding = compact ? 'py-1 px-2' : 'py-2 px-3';
   const formClass = cn(
     'bg-white p-4 rounded-md shadow-sm',
-    compact ? 'space-y-1 mb-16' : 'space-y-2 mb-28'
+    compact ? 'space-y-1 pb-16' : 'space-y-2 pb-28'
   );
 
   return (
@@ -288,6 +293,21 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
           className={cn('w-full text-sm', inputPadding, 'rounded-md border-gray-300 focus:ring-primary')}
         />
       </div>
+
+      {editedTransaction.type === 'transfer' && (
+        <div className={rowClass}>
+          <label className={labelClass}>To Account*</label>
+
+          <Input
+            value={editedTransaction.toAccount || ''}
+            onChange={(e) => handleChange('toAccount', e.target.value)}
+            style={getDrivenFieldStyle('toAccount', drivenFields)}
+            placeholder="Destination account"
+            required
+            className={cn('w-full text-sm', inputPadding, 'rounded-md border-gray-300 focus:ring-primary')}
+          />
+        </div>
+      )}
 
 
       <div className={rowClass}>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -23,7 +23,9 @@ const Header = ({ className, showNavigation = true, showBack = false }: HeaderPr
   const navigate = useNavigate();
   const { auth } = useUser();
   
-  const currentPageTitle = routeTitleMap[location.pathname] || 'Xpensia';
+  const currentPageTitle =
+    routeTitleMap[location.pathname] ||
+    (location.pathname.startsWith('/edit-transaction') ? 'Transaction' : 'Xpensia');
   const isLandingPage = location.pathname === '/';
   const isAuthPage = location.pathname === '/onboarding';
   // Show navigation on all pages except landing and onboarding

--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -18,6 +18,7 @@ export const routeTitleMap: Record<string, string> = {
   '/wireframes/sms-provider': 'SMS Provider',
   '/wireframes/sms-transaction': 'SMS Transaction',
   '/import-transactions': 'Import Transactions',
+  '/edit-transaction': 'Transaction',
 };
 
 // Navigation items that appear in the header

--- a/src/pages/AddTransaction.tsx
+++ b/src/pages/AddTransaction.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   CardContent,
   CardHeader,
+  CardTitle,
 } from '@/components/ui/card';
 import { useTransactions } from '@/context/TransactionContext';
 import TransactionEditForm from '@/components/TransactionEditForm';
@@ -38,7 +39,9 @@ const AddTransaction = () => {
       >
 
         <Card className="w-full">
-          <CardHeader className="pb-2" />
+          <CardHeader className="pb-2">
+            <CardTitle>Add Transaction</CardTitle>
+          </CardHeader>
           <CardContent className="pt-0">
             <TransactionEditForm onSave={handleSave} compact showNotes={false} />
           </CardContent>

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -128,11 +128,16 @@ const EditTransaction = () => {
         <Card className="w-full">
           <CardHeader className="pb-2">
             <CardTitle>
-              {isNewTransaction ? 'Create a new transaction' : 'Edit transaction details'}
+              {isNewTransaction ? 'Add Transaction' : 'Edit Transaction'}
             </CardTitle>
           </CardHeader>
           <CardContent className="pt-0">
-            <TransactionEditForm transaction={transaction} onSave={handleSave} />
+            <TransactionEditForm
+              transaction={transaction}
+              onSave={handleSave}
+              compact
+              showNotes={false}
+            />
           </CardContent>
         </Card>
       </motion.div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -288,7 +288,11 @@ const Home = () => {
                   {filteredTransactions.slice(0, 5).map((transaction, idx) => (
                     <div
                       key={transaction.id || idx}
-                      onClick={() => navigate(`/edit-transaction/${transaction.id}`)}
+                      onClick={() =>
+                        navigate(`/edit-transaction/${transaction.id}`, {
+                          state: { transaction },
+                        })
+                      }
                       aria-label="Edit transaction"
                       className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 hover:shadow-md hover:bg-gray-50 transition-all cursor-pointer"
                     >


### PR DESCRIPTION
## Summary
- show to-account field for transfers in the transaction form
- update Add Transaction page header
- refine Edit Transaction page layout and hide notes
- register edit-transaction route title for header
- fix header on edit page and remove bottom margins from form
- pass transaction state when editing from recent transactions

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68545c3305588333962e5e7b71297a84