### PR TITLE
Remove unused import

### DIFF
--- a/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsProcessingService.java
+++ b/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsProcessingService.java
@@ -11,7 +11,6 @@ import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
-import com.getcapacitor.JSObject;
 
 public class SmsProcessingService extends Service {
     private static final String TAG = "SmsProcessingService";


### PR DESCRIPTION
## Summary
- remove `JSObject` import from SmsProcessingService

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68552f8f752c8333ae426a677733efe9