### PR TITLE
Fix unmatched closing div in Transactions page

### DIFF
--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -137,7 +137,6 @@ const Transactions = () => {
             </Button>
           </div>
         </div>
-      </div>
       
       <div className="px-[var(--page-padding-x)] pt-2 pb-24 mt-1">
         {filteredTransactions.length > 0 ? (


### PR DESCRIPTION
## Summary
- fix mismatched closing tag in `Transactions` page which caused build failures

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855376c667c8333beb498a6ab350dcc