### PR TITLE
Add debug logs for background SMS

### DIFF
--- a/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
+++ b/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
@@ -47,6 +47,7 @@ public class BackgroundSmsListenerPlugin extends Plugin {
 
     @Override
     public void load() {
+        Log.d(TAG, "Plugin load() called");
         super.load();
         instance = this;
         deliverPersistedMessages();
@@ -78,6 +79,7 @@ public class BackgroundSmsListenerPlugin extends Plugin {
     }
 
     private void deliverPersistedMessages() {
+        Log.d(TAG, "Checking for persisted messages");
         synchronized (PREF_LOCK) {
             SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
             String stored = prefs.getString(PREF_KEY, null);
@@ -96,6 +98,8 @@ public class BackgroundSmsListenerPlugin extends Plugin {
                     Log.e(TAG, "Failed to parse persisted SMS messages", e);
                 }
                 prefs.edit().remove(PREF_KEY).apply();
+            } else {
+                Log.d(TAG, "No persisted SMS messages found");
             }
         }
     }
@@ -121,6 +125,7 @@ public class BackgroundSmsListenerPlugin extends Plugin {
 
             arr.put(obj);
             prefs.edit().putString(PREF_KEY, arr.toString()).apply();
+            Log.d(TAG, "Persisted SMS from " + sender);
         }
     }
 

--- a/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
+++ b/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
@@ -47,6 +47,7 @@ public class BackgroundSmsListenerPlugin extends Plugin {
 
     @Override
     public void load() {
+        Log.d(TAG, "Plugin load() called");
         super.load();
         instance = this;
         deliverPersistedMessages();
@@ -78,6 +79,7 @@ public class BackgroundSmsListenerPlugin extends Plugin {
     }
 
     private void deliverPersistedMessages() {
+        Log.d(TAG, "Checking for persisted messages");
         synchronized (PREF_LOCK) {
             SharedPreferences prefs = getContext().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
             String stored = prefs.getString(PREF_KEY, null);
@@ -96,6 +98,8 @@ public class BackgroundSmsListenerPlugin extends Plugin {
                     Log.e(TAG, "Failed to parse persisted SMS messages", e);
                 }
                 prefs.edit().remove(PREF_KEY).apply();
+            } else {
+                Log.d(TAG, "No persisted SMS messages found");
             }
         }
     }
@@ -121,6 +125,7 @@ public class BackgroundSmsListenerPlugin extends Plugin {
 
             arr.put(obj);
             prefs.edit().putString(PREF_KEY, arr.toString()).apply();
+            Log.d(TAG, "Persisted SMS from " + sender);
         }
     }
 


### PR DESCRIPTION
## Summary
- log when the plugin loads
- log when persisted SMS messages are checked or missing
- log when SMS data is persisted

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554365238483339549ca16892eae91