### PR TITLE
Add SmsProcessingService to background SMS plugin

### DIFF
--- a/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsProcessingService.java
+++ b/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsProcessingService.java
@@ -1,0 +1,76 @@
+package app.xpensia.com.plugins.backgroundsmslistener;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+
+
+public class SmsProcessingService extends Service {
+    private static final String TAG = "SmsProcessingService";
+    private static final String CHANNEL_ID = "SmsProcessingChannel";
+    private static final int NOTIFICATION_ID = 1;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("SMS Listener")
+            .setContentText("Processing incoming SMS")
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .build();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        } else {
+            startForeground(NOTIFICATION_ID, notification);
+        }
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        String sender = intent.getStringExtra("sender");
+        String body = intent.getStringExtra("body");
+
+        if (sender != null && body != null) {
+            Log.d(TAG, "Processing SMS from " + sender + ": " + body);
+            BackgroundSmsListenerPlugin.notifySmsReceived(getApplicationContext(), sender, body);
+        }
+
+        stopSelf();
+
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        Log.d(TAG, "SmsProcessingService destroyed");
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                "SMS Processing",
+                NotificationManager.IMPORTANCE_LOW
+            );
+            NotificationManager manager = getSystemService(NotificationManager.class);
+            if (manager != null) {
+                manager.createNotificationChannel(channel);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SmsProcessingService.java` to plugin's Android sources
- ensure the service starts foreground with data sync type
- package the plugin successfully using `npm pack`

## Testing
- `npm install` within plugin
- `npm pack`

------
https://chatgpt.com/codex/tasks/task_e_6855487cb94c8333b3307c246a33f142