### PR TITLE
fix: correct Gradle java home path

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,4 +21,4 @@ org.gradle.jvmargs=-Xmx1536m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64


### PR DESCRIPTION
## Summary
- update the `org.gradle.java.home` path in `android/gradle.properties` to point to `java-21-openjdk-amd64`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68554f0095fc8333943d84f6b5e5fce7