### PR TITLE
Fix static SMS duplicate events

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,7 @@ BackgroundSmsListener.addListener('smsReceived', ({ sender, body }) => {
 
 This ensures SMS messages received while the app was not running are delivered on next startup.
 
+Duplicate SMS events should no longer occur when the listener is active, as the
+static receiver now checks whether the plugin is running before persisting or
+processing messages.
+

--- a/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
+++ b/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
@@ -50,6 +50,14 @@ public class BackgroundSmsListenerPlugin extends Plugin {
     private boolean isListening = false;
     private BroadcastReceiver smsReceiver;
 
+    /**
+     * Returns true if the plugin instance exists and is actively listening for
+     * SMS messages.
+     */
+    public static boolean isPluginActive() {
+        return instance != null && instance.isListening;
+    }
+
     @Override
     public void load() {
         Log.d(INIT_TAG, "Plugin load() called");
@@ -80,7 +88,6 @@ public class BackgroundSmsListenerPlugin extends Plugin {
             synchronized (pendingMessages) {
                 pendingMessages.add(data);
             }
-            persistMessage(context, sender, body);
         }
     }
 

--- a/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsBroadcastReceiver.java
+++ b/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsBroadcastReceiver.java
@@ -17,6 +17,11 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (Telephony.Sms.Intents.SMS_RECEIVED_ACTION.equals(intent.getAction())) {
+            if (BackgroundSmsListenerPlugin.isPluginActive()) {
+                Log.d(TAG, "Plugin active, ignoring static receiver event");
+                return;
+            }
+
             SmsMessage[] messages = null;
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
+++ b/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
@@ -50,6 +50,14 @@ public class BackgroundSmsListenerPlugin extends Plugin {
     private boolean isListening = false;
     private BroadcastReceiver smsReceiver;
 
+    /**
+     * Returns true if the plugin instance exists and is actively listening for
+     * SMS messages.
+     */
+    public static boolean isPluginActive() {
+        return instance != null && instance.isListening;
+    }
+
     @Override
     public void load() {
         Log.d(INIT_TAG, "Plugin load() called");
@@ -80,7 +88,6 @@ public class BackgroundSmsListenerPlugin extends Plugin {
             synchronized (pendingMessages) {
                 pendingMessages.add(data);
             }
-            persistMessage(context, sender, body);
         }
     }
 

--- a/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsBroadcastReceiver.java
+++ b/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/SmsBroadcastReceiver.java
@@ -17,6 +17,11 @@ public class SmsBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (Telephony.Sms.Intents.SMS_RECEIVED_ACTION.equals(intent.getAction())) {
+            if (BackgroundSmsListenerPlugin.isPluginActive()) {
+                Log.d(TAG, "Plugin active, ignoring static receiver event");
+                return;
+            }
+
             SmsMessage[] messages = null;
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/capacitor-background-sms-listener/package-lock.json
+++ b/capacitor-background-sms-listener/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-background-sms-listener",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-background-sms-listener",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/core": "latest"

--- a/capacitor-background-sms-listener/package.json
+++ b/capacitor-background-sms-listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-background-sms-listener",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Capacitor plugin for background SMS listening",
   "main": "dist/plugin.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary
- prevent duplicate SMS events by checking if plugin is active
- remove persistence when JavaScript listener is connected
- bump background SMS listener plugin version
- document that duplicate events no longer happen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855894d654883338adb1404334b6cfc