### PR TITLE
Remove duplicate import statements

### DIFF
--- a/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
+++ b/android/app/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
@@ -13,7 +13,6 @@ import android.provider.Telephony;
 import android.telephony.SmsMessage;
 import android.util.Log;
 import android.content.ComponentName;
-import android.content.pm.PackageManager;
 
 import androidx.core.content.ContextCompat;
 

--- a/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
+++ b/capacitor-background-sms-listener/android/src/main/java/app/xpensia/com/plugins/backgroundsmslistener/BackgroundSmsListenerPlugin.java
@@ -13,7 +13,6 @@ import android.provider.Telephony;
 import android.telephony.SmsMessage;
 import android.util.Log;
 import android.content.ComponentName;
-import android.content.pm.PackageManager;
 
 import androidx.core.content.ContextCompat;
 


### PR DESCRIPTION
## Summary
- remove redundant `PackageManager` import from Android plugins

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68558a82a0108333bcabf4c4797be229