### PR TITLE
Add data sync service permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,6 +62,7 @@
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     
     <!-- Network state monitoring -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/capacitor-background-sms-listener/android/src/main/AndroidManifest.xml
+++ b/capacitor-background-sms-listener/android/src/main/AndroidManifest.xml
@@ -20,4 +20,5 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
     </application>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 </manifest>


### PR DESCRIPTION
## Summary
- add FOREGROUND_SERVICE_DATA_SYNC permission to app manifest
- add the same permission in the background SMS listener manifest

## Testing
- `npm ci` *(fails: ENETUNREACH to github.com)*
- `npx cap sync android` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_68558c3e9fd883339648613fdec5232f