### PR TITLE
Fix duplicate page title on Transactions

### DIFF
--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -61,9 +61,9 @@ const Transactions = () => {
   });
   
   return (
-    <Layout withPadding={false}>
+    <Layout withPadding={false} showBack>
       <PageHeader
-        title="Transactions"
+        title={null}
         className="pt-2"
         actions={
           <>


### PR DESCRIPTION
## Summary
- remove text title from Transactions PageHeader
- enable back button via `showBack` on Layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68559241a8f48333a8a8c79ab7edd4c7