### PR TITLE
Improve transaction list layout

### DIFF
--- a/src/components/transactions/SwipeableTransactionCard.tsx
+++ b/src/components/transactions/SwipeableTransactionCard.tsx
@@ -85,7 +85,7 @@ const SwipeableTransactionCard: React.FC<SwipeableTransactionCardProps> = ({
   }
 
   return (
-    <div className="relative overflow-hidden rounded-lg mb-2" ref={constraintsRef}>
+    <div className="relative overflow-hidden rounded-2xl mb-2" ref={constraintsRef}>
       {/* Background elements */}
       <div className="absolute inset-0 flex justify-between items-stretch">
         <div className="bg-blue-500 w-1/2 flex items-center justify-center">
@@ -103,7 +103,7 @@ const SwipeableTransactionCard: React.FC<SwipeableTransactionCardProps> = ({
         onDragStart={() => setIsDragging(true)}
         onDragEnd={handleDragEnd}
         animate={controls}
-        className="relative bg-card rounded-lg shadow z-10"
+        className="relative bg-card rounded-2xl shadow-sm z-10"
       >
         <Card className="p-[var(--card-padding)] cursor-grab active:cursor-grabbing">
           <div className="flex justify-between items-center">

--- a/src/components/transactions/TransactionCard.tsx
+++ b/src/components/transactions/TransactionCard.tsx
@@ -118,7 +118,7 @@ import { CATEGORY_COLOR_MAP } from '@/constants/categoryColors';
 			  transition={{ duration: 0.2 }}
 			  className={className}
 			>
-                          <Card className="overflow-hidden border hover:shadow-md transition-all duration-200">
+                          <Card className="overflow-hidden border rounded-2xl shadow-sm transition-all duration-200">
                                 <CardContent className="p-[var(--card-padding)]">
 				  <div className="flex items-center justify-between">
 					<div className="flex items-center space-x-3">

--- a/src/components/transactions/TransactionsByDate.tsx
+++ b/src/components/transactions/TransactionsByDate.tsx
@@ -38,16 +38,27 @@ const TransactionsByDate: React.FC<TransactionsByDateProps> = ({
     }
   };
 
+  const categoryEmoji = (category: string) => {
+    const map: Record<string, string> = {
+      Health: '💊',
+      Transportation: '🚗',
+      Earnings: '💼',
+    };
+    return map[category] || '🛒';
+  };
+
   return (
-    <div className="space-y-6">
-      {sortedDates.map(date => (
-        <div key={date} className="space-y-2">
+    <div className="space-y-[var(--card-gap)] px-[var(--page-padding-x)]">
+      {sortedDates.map(date => {
+        const net = groupedTransactions[date].reduce((s, t) => s + t.amount, 0);
+        return (
+        <div key={date} className="space-y-[var(--card-gap)]">
           <h3 className="font-semibold text-gray-600 text-sm">
             {formatDate(date)}
           </h3>
-          
-          <div className="space-y-2">
-           {groupedTransactions[date].map((transaction, index) => {
+
+          <div className="space-y-[var(--card-gap)]">
+            {groupedTransactions[date].map((transaction, index) => {
   if (!transaction.id?.trim()) {
     console.warn('⚠️ Empty or invalid transaction.id:', transaction);
   }
@@ -55,33 +66,40 @@ const TransactionsByDate: React.FC<TransactionsByDateProps> = ({
   return (
     <div
       key={transaction.id?.trim() || `txn-${date}-${index}`}
-      className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3"
+        className="bg-white rounded-2xl shadow-sm border border-gray-200 px-4 py-3"
     >
-      <div className="flex justify-between items-center">
-        <div className="flex-1">
-          <h4 className="font-medium">{transaction.title}</h4>
-          <p className="text-sm text-muted-foreground">{transaction.category}</p>
-        </div>
+        <div className="flex justify-between items-center">
+          <div>
+            <h4 className="font-medium text-sm">{transaction.title}</h4>
+            <span className="mt-0.5 inline-flex items-center gap-1 text-xs rounded px-2 py-0.5 bg-muted text-muted-foreground">
+              {categoryEmoji(transaction.category)} {transaction.category}
+            </span>
+          </div>
 
-        <div className="flex items-center gap-4">
-          <span
-            className={`font-semibold ${
-              transaction.amount < 0 ? 'text-red-600' : 'text-green-600'
-            }`}
-          >
-            {formatCurrency(transaction.amount)}
-          </span>
+          <div className="flex items-center gap-4">
+            <span
+              className={`font-semibold ${
+                transaction.amount < 0 ? 'text-red-600' : 'text-green-600'
+              }`}
+            >
+              {formatCurrency(transaction.amount)}
+            </span>
 
-          <TransactionActions transaction={transaction} variant="dropdown" />
-        </div>
-      </div>
-    </div>
-  );
-})}
-
+            <TransactionActions transaction={transaction} variant="dropdown" />
           </div>
         </div>
-      ))}
+      </div>
+    );
+  });
+
+          </div>
+            <div className="text-right text-sm font-semibold">
+              Net: {formatCurrency(net)}
+            </div>
+          </div>
+        </div>
+      );
+    })
     </div>
   );
 };

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -97,7 +97,7 @@ const Transactions = () => {
         }
       />
 
-      <div className="px-1">
+      <div className="px-[var(--page-padding-x)]">
         {/* Search and Filters */}
         <div className="flex flex-col sm:flex-row gap-2 items-center pt-2">
           <div className="relative flex-1 w-full">


### PR DESCRIPTION
## Summary
- tweak padding for the Transactions page
- restyle transaction cards with rounded corners and subtle shadows
- show category emojis and daily net totals

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855cdfbdc948333b071d417bbe274de