### PR TITLE
Fix extra closing div in Transactions page

### DIFF
--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -91,7 +91,6 @@ const Transactions = () => {
               Filter
             </Button>
           </div>
-          </div>
 
           <div className="pt-2 pb-24 mt-1">
           {filteredTransactions.length > 0 ? (


### PR DESCRIPTION
## Summary
- fix incorrect closing div in Transactions

## Testing
- `npm run build` *(fails: `vite` not found)*
- `npm install` *(fails: connect ENETUNREACH 140.82.112.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_6855dd8ec6d483338f56ab9ae19be969