### PR TITLE
Fix transactions header spacing

### DIFF
--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -100,9 +100,9 @@ const Transactions = () => {
   
   return (
     <Layout withPadding={false} showBack fullWidth>
-      <PageHeader title={null} className="pt-2" />
+      <PageHeader title={null} />
 
-      <div className="sticky top-[var(--header-height)] z-10 bg-background px-[var(--page-padding-x)] pt-2 pb-2 space-y-2">
+      <div className="sticky top-[var(--header-height)] z-10 bg-background px-[var(--page-padding-x)] pt-0 pb-2 -mt-[7px] space-y-2">
         <ToggleGroup
           type="single"
           value={range}
@@ -113,14 +113,14 @@ const Transactions = () => {
             <ToggleGroupItem
               key={r}
               value={r}
-              className="flex-1 text-xs transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
+              className="flex-1 transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
             >
               {r.charAt(0).toUpperCase() + r.slice(1)}
             </ToggleGroupItem>
           ))}
           <ToggleGroupItem
             value="custom"
-            className="flex-1 text-xs transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
+            className="flex-1 transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
           >
             Custom
           </ToggleGroupItem>
@@ -143,7 +143,7 @@ const Transactions = () => {
             <ToggleGroupItem
               key={f}
               value={f}
-              className="flex-1 text-xs transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
+              className="flex-1 transition-colors data-[state=on]:bg-primary data-[state=on]:text-primary-foreground font-medium"
             >
               {f.charAt(0).toUpperCase() + f.slice(1)}
             </ToggleGroupItem>


### PR DESCRIPTION
## Summary
- remove padding from transactions page header
- adjust sticky filter spacing so filter block sits flush under header
- match transactions page toggle text style to the home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm i` *(fails: ENETUNREACH to github.com for onnxruntime download)*

------
https://chatgpt.com/codex/tasks/task_e_6855e560e3d8833381edf21a4cc0134b