### PR TITLE
Add demo transaction seeding

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { ErrorType, ErrorSeverity } from './types/error'
 import { initializeXpensiaStorageDefaults } from './lib/smart-paste-engine/initializeXpensiaStorageDefaults';
 import './styles/app.css';
 import { initializeCapacitor } from './lib/capacitor-init';
+import { demoTransactionService } from './services/DemoTransactionService';
 
 // Initialize Capacitor
 try {
@@ -16,6 +17,7 @@ try {
 }
 
 initializeXpensiaStorageDefaults();
+demoTransactionService.seedDemoTransactions();
 
 
 // Setup global error handlers

--- a/src/services/DemoTransactionService.ts
+++ b/src/services/DemoTransactionService.ts
@@ -1,0 +1,92 @@
+import { Transaction, TransactionType } from '@/types/transaction';
+import { v4 as uuidv4 } from 'uuid';
+import { getCategoryHierarchy, CURRENCIES } from '@/lib/categories-data';
+import { getStoredTransactions, storeTransactions } from '@/utils/storage-utils';
+
+const FROM_ACCOUNTS = [
+  'SAB Bank Debit',
+  'SAB Bank Credit',
+  'ALRajhi Bank Debit',
+  'AlRajhi Bank Credit',
+  'D360 Bank Debit',
+  'HSBC Egypt Bank Debit',
+  'STC Pay',
+  'UPay',
+  'Instapay',
+  'Cash',
+  'Work Company Account'
+];
+
+const VENDORS = [
+  'restaurant','cafe','starbucks','mcdonald','kfc','pizza',
+  'amazon','ikea','market','grocery','supermarket','panda','tamimi','danube','carrefour','lulu','mall',
+  'uber','careem','taxi','gas','petrol','fuel','aldrees',
+  'electric','water','internet','phone','mobile','stc','zain','mobily',
+  'netflix','spotify','cinema','theater',
+  'pharmacy','doctor','hospital','clinic','medical'
+];
+
+const INIT_FLAG_KEY = 'xpensia_demo_transactions_initialized';
+
+class DemoTransactionService {
+  seedDemoTransactions(): void {
+    if (localStorage.getItem(INIT_FLAG_KEY)) {
+      return;
+    }
+
+    const existing = getStoredTransactions();
+    if (existing.length > 0) {
+      localStorage.setItem(INIT_FLAG_KEY, 'true');
+      return;
+    }
+
+    const categories = getCategoryHierarchy();
+    const start = new Date();
+    start.setFullYear(start.getFullYear() - 1);
+    const end = new Date();
+
+    const newTransactions: Transaction[] = [];
+
+    const randomDate = () => {
+      const time = start.getTime() + Math.random() * (end.getTime() - start.getTime());
+      const d = new Date(time);
+      return d.toISOString().split('T')[0];
+    };
+
+    const randomAmount = (type: TransactionType) => {
+      const val = Number((Math.random() * 500 + 5).toFixed(2));
+      if (type === 'income') return val;
+      if (type === 'transfer') return Math.random() > 0.5 ? val : -val;
+      return -val;
+    };
+
+    const randomItem = <T,>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)];
+
+    categories.forEach(cat => {
+      const subs = cat.subcategories.length > 0 ? cat.subcategories.map(s => s.name) : [cat.name];
+      subs.forEach(sub => {
+        for (let i = 0; i < 4; i++) {
+          newTransactions.push({
+            id: uuidv4(),
+            title: sub,
+            amount: randomAmount(cat.type as TransactionType),
+            category: cat.name,
+            subcategory: sub !== cat.name ? sub : undefined,
+            date: randomDate(),
+            type: cat.type as TransactionType,
+            notes: 'Demo seed transaction',
+            source: 'manual',
+            currency: randomItem(CURRENCIES),
+            fromAccount: randomItem(FROM_ACCOUNTS),
+            vendor: randomItem(VENDORS)
+          });
+        }
+      });
+    });
+
+    storeTransactions([...existing, ...newTransactions]);
+    localStorage.setItem(INIT_FLAG_KEY, 'true');
+  }
+}
+
+export const demoTransactionService = new DemoTransactionService();


### PR DESCRIPTION
## Summary
- create `DemoTransactionService` that seeds sample transactions for the last year
- initialize demo data on application start in `main.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568c1554748333a90b6152b141eb40