### PR TITLE
Increase label radius on donut chart

### DIFF
--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -8,7 +8,7 @@ import { CHART_COLORS } from '@/constants/analytics';
 const RADIAN = Math.PI / 180;
 
 const renderLabelLine = ({ cx, cy, midAngle, outerRadius }: any) => {
-  const radius = outerRadius + 6;
+  const radius = outerRadius + 12;
   const sx = cx + outerRadius * Math.cos(-midAngle * RADIAN);
   const sy = cy + outerRadius * Math.sin(-midAngle * RADIAN);
   const ex = cx + radius * Math.cos(-midAngle * RADIAN);
@@ -17,7 +17,7 @@ const renderLabelLine = ({ cx, cy, midAngle, outerRadius }: any) => {
 };
 
 const renderLabel = ({ cx, cy, midAngle, outerRadius, percent }: any) => {
-  const radius = outerRadius + 8;
+  const radius = outerRadius + 20;
   const x = cx + radius * Math.cos(-midAngle * RADIAN);
   const y = cy + radius * Math.sin(-midAngle * RADIAN);
   return (


### PR DESCRIPTION
## Summary
- tweak CategoryChart label connector to extend outward
- move percentage labels farther away from the donut

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68569180c1c88333870fd37031a4fbf3