### PR TITLE
Fix donut chart text centering

### DIFF
--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -62,7 +62,7 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
         {hasData ? (
           limited.length > 1 ? (
             <div
-              className="h-[300px] w-full flex items-center"
+              className="h-[300px] w-full"
               role="img"
               aria-label="Expenses by category donut chart"
             >


### PR DESCRIPTION
## Summary
- rely solely on chart coordinates for donut center text in `CategoryChart`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856934a6af08333a2f15ac701287261