### PR TITLE
Add chart color utility

### DIFF
--- a/src/components/charts/CategoryBreakdownChart.tsx
+++ b/src/components/charts/CategoryBreakdownChart.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CategorySummary } from '@/types/transaction';
-import { CHART_COLORS } from '@/constants/analytics';
+import { getChartColor } from '@/utils/color-utils';
 
 interface CategoryBreakdownChartProps {
   data: CategorySummary[];
@@ -33,7 +33,7 @@ const CategoryBreakdownChart: React.FC<CategoryBreakdownChartProps> = ({ data })
               label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
             >
               {chartData.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                <Cell key={`cell-${index}`} fill={getChartColor(index)} />
               ))}
             </Pie>
             <Tooltip formatter={(value: number) => [`$${value.toFixed(2)}`, 'Amount']} />

--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import { formatCurrency } from '@/lib/formatters';
-import { CHART_COLORS } from '@/constants/analytics';
+import { getChartColor } from '@/utils/color-utils';
 
 
 const RADIAN = Math.PI / 180;
@@ -83,7 +83,7 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
 
                   >
                     {limited.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                      <Cell key={`cell-${index}`} fill={getChartColor(index)} />
                     ))}
                   </Pie>
                   <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle" className="text-sm fill-foreground">

--- a/src/components/charts/SubcategoryChart.tsx
+++ b/src/components/charts/SubcategoryChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { formatCurrency } from '@/lib/formatters';
-import { CHART_COLORS } from '@/constants/analytics';
+import { getChartColor } from '@/utils/color-utils';
 
 interface Item {
   name: string;
@@ -64,7 +64,7 @@ const SubcategoryChart: React.FC<SubcategoryChartProps> = ({ data }) => {
                 <Tooltip content={BarTooltip(total)} />
                 <Bar dataKey="value" radius={[4, 4, 4, 4]} isAnimationActive>
                   {data.map((_, index) => (
-                    <Cell key={`cell-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                    <Cell key={`cell-${index}`} fill={getChartColor(index)} />
                   ))}
                 </Bar>
               </BarChart>

--- a/src/utils/color-utils.ts
+++ b/src/utils/color-utils.ts
@@ -1,0 +1,87 @@
+import { CHART_COLORS } from '@/constants/analytics';
+
+interface Hsl {
+  h: number;
+  s: number;
+  l: number;
+}
+
+function hexToHsl(hex: string): Hsl {
+  hex = hex.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return { h: h * 360, s: s * 100, l: l * 100 };
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  h /= 360;
+  s /= 100;
+  l /= 100;
+
+  let r: number, g: number, b: number;
+
+  if (s === 0) {
+    r = g = b = l; // achromatic
+  } else {
+    const hue2rgb = (p: number, q: number, t: number) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+
+  const toHex = (x: number) => Math.round(x * 255).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function adjustLightness(hex: string, amount: number): string {
+  const { h, s, l } = hexToHsl(hex);
+  const newL = Math.min(100, Math.max(0, l + amount));
+  return hslToHex(h, s, newL);
+}
+
+export function getChartColor(index: number): string {
+  const base = CHART_COLORS[index % CHART_COLORS.length];
+  const cycle = Math.floor(index / CHART_COLORS.length);
+  if (cycle === 0) return base;
+
+  const magnitude = 15 * Math.floor((cycle + 1) / 2);
+  const direction = cycle % 2 === 1 ? 1 : -1;
+  return adjustLightness(base, direction * magnitude);
+}
+
+export { hexToHsl, hslToHex, adjustLightness };


### PR DESCRIPTION
## Summary
- add `getChartColor` utility to generate color variations
- use the new utility in CategoryChart, SubcategoryChart and CategoryBreakdownChart

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm install` *(fails: ENETUNREACH on GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68569459d6548333a5e1ead49f8dc147