### PR TITLE
use vendor fallbacks from storage

### DIFF
--- a/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
+++ b/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
@@ -1,4 +1,6 @@
 import { TransactionType } from '@/types/transaction';
+import vendorFallbackData from '../../data/ksa_all_vendors_clean_final.json';
+import { saveVendorFallbacks } from './vendorFallbackUtils';
 
 
 
@@ -212,6 +214,12 @@ export function initializeXpensiaStorageDefaults() {
   if (!localStorage.getItem('xpensia_vendor_map')) {
     localStorage.setItem('xpensia_vendor_map', JSON.stringify({}));
     console.log('[Init] xpensia_vendor_map initialized');
+  }
+
+  // Ensure vendor fallback data exists
+  if (!localStorage.getItem('xpensia_vendor_fallbacks')) {
+    saveVendorFallbacks((vendorFallbackData as any).default ?? vendorFallbackData);
+    console.log('[Init] xpensia_vendor_fallbacks initialized');
   }
 
   // Ensure type keyword bank exists

--- a/src/lib/smart-paste-engine/suggestionEngine.ts
+++ b/src/lib/smart-paste-engine/suggestionEngine.ts
@@ -4,9 +4,10 @@
  */
 
 import stringSimilarity from 'string-similarity';
-import * as vendorData from '../../data/ksa_all_vendors_clean_final.json';
-const fallbackVendors: Record<string, FallbackVendorEntry> =
-  ((vendorData as any).default ?? vendorData) as Record<string, FallbackVendorEntry>;
+import {
+  loadVendorFallbacks,
+  VendorFallbackData,
+} from './vendorFallbackUtils';
 
 const BANK_KEY = 'xpensia_keyword_bank';
 
@@ -18,12 +19,13 @@ export interface KeywordMapping {
   }[];
 }
 
-interface FallbackVendorEntry {
+interface FallbackVendorEntry extends VendorFallbackData {
   vendor: string;
-  type: 'expense' | 'income' | 'transfer';
-  category: string;
-  subcategory: string;
 }
+
+const getFallbackVendors = (): Record<string, VendorFallbackData> => {
+  return loadVendorFallbacks();
+};
 
 
 // Utility to normalize vendor names
@@ -66,6 +68,7 @@ const normalize = (str: string): string =>
 
 export function findClosestFallbackMatch(vendorName: string): FallbackVendorEntry | null {
   const lowerInput = softNormalize(vendorName);
+  const fallbackVendors = getFallbackVendors();
   const vendorKeys = Object.keys(fallbackVendors);
 
   // Step 1: Try full fuzzy match
@@ -109,7 +112,7 @@ export function findClosestFallbackMatch(vendorName: string): FallbackVendorEntr
   }
 
   console.log('[DEBUG] keywordBank:', keywordBank);
-  console.log('[DEBUG] fallbackVendors:', fallbackVendors);
+  console.log('[DEBUG] fallbackVendors:', getFallbackVendors());
 
   // ⬇️ Keyword-based inference
   keywordBank.forEach(({ keyword, mappings }) => {

--- a/src/lib/smart-paste-engine/vendorFallbackUtils.ts
+++ b/src/lib/smart-paste-engine/vendorFallbackUtils.ts
@@ -1,0 +1,24 @@
+export interface VendorFallbackData {
+  type: 'expense' | 'income' | 'transfer';
+  category: string;
+  subcategory: string;
+}
+
+const KEY = 'xpensia_vendor_fallbacks';
+
+export function loadVendorFallbacks(): Record<string, VendorFallbackData> {
+  const raw = localStorage.getItem(KEY);
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, VendorFallbackData>;
+  } catch (e) {
+    console.error('[VendorFallbackUtils] Failed to parse stored vendor data:', e);
+    return {};
+  }
+}
+
+export function saveVendorFallbacks(data: Record<string, VendorFallbackData>): void {
+  localStorage.setItem(KEY, JSON.stringify(data));
+}
+
+export { KEY as VENDOR_FALLBACK_KEY };


### PR DESCRIPTION
## Summary
- move vendor fallback data into localStorage
- save default vendor fallback map on initialization
- load vendor fallback map from storage when inferring fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68569b743a44833388579f003bd6442a