### PR TITLE
Add account dropdown with dialog

### DIFF
--- a/src/lib/account-utils.ts
+++ b/src/lib/account-utils.ts
@@ -1,0 +1,40 @@
+export interface Account {
+  name: string;
+  iban?: string;
+  user?: boolean;
+}
+
+const ACCOUNTS_KEY = 'xpensia_accounts';
+
+export const DEFAULT_ACCOUNTS: Account[] = [
+  { name: 'Cash' },
+  { name: 'Bank Account' },
+  { name: 'Credit Card' },
+  { name: 'Savings' },
+  { name: 'Investment' },
+  { name: 'Other' }
+];
+
+export function getStoredAccounts(): Account[] {
+  try {
+    const raw = localStorage.getItem(ACCOUNTS_KEY);
+    const userAccounts: Account[] = raw ? JSON.parse(raw) : [];
+    return [...DEFAULT_ACCOUNTS, ...userAccounts];
+  } catch {
+    return [...DEFAULT_ACCOUNTS];
+  }
+}
+
+export function addUserAccount(account: Account) {
+  if (!account.name.trim()) return;
+  try {
+    const raw = localStorage.getItem(ACCOUNTS_KEY);
+    const arr: Account[] = raw ? JSON.parse(raw) : [];
+    if (!arr.some(a => a.name.toLowerCase() === account.name.toLowerCase())) {
+      arr.push({ ...account, user: true });
+      localStorage.setItem(ACCOUNTS_KEY, JSON.stringify(arr));
+    }
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- allow entering From/To accounts from a dropdown with free text support
- let user create new accounts with a dialog
- store created accounts in `localStorage` using a new helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5d8f60c8333b18b50f6d92a33dd