### PR TITLE
Add custom people support

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/categories-data';
 import { Plus, Calculator } from 'lucide-react';
 import { getStoredAccounts, addUserAccount, Account } from '@/lib/account-utils';
+import { getPeopleNames, addUserPerson } from '@/lib/people-utils';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -118,6 +119,10 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
     category: string;
     subcategory: string;
   }>({ type: 'expense', category: '', subcategory: '' });
+
+  const [people, setPeople] = useState<string[]>(() => getPeopleNames());
+  const [addPersonOpen, setAddPersonOpen] = useState(false);
+  const [newPerson, setNewPerson] = useState<{ name: string; relation: string }>({ name: '', relation: '' });
 
   const [editedTransaction, setEditedTransaction] = useState<Transaction>(() => {
     if (transaction) {
@@ -277,6 +282,15 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
 
     setNewCategory({ type: editedTransaction.type, category: '', subcategory: '' });
     setAddCategoryOpen(false);
+  };
+
+  const handleSavePerson = () => {
+    if (!newPerson.name.trim()) return;
+    addUserPerson({ name: newPerson.name.trim(), relation: newPerson.relation.trim() || undefined });
+    setPeople(getPeopleNames());
+    handleChange('person', newPerson.name.trim());
+    setNewPerson({ name: '', relation: '' });
+    setAddPersonOpen(false);
   };
 
   const handleCalcInput = (val: string) => {
@@ -513,6 +527,28 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
         </DialogContent>
       </Dialog>
 
+      <Dialog open={addPersonOpen} onOpenChange={setAddPersonOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Person</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <div>
+              <label className="mb-1 block text-sm font-medium">Name*</label>
+              <Input value={newPerson.name} onChange={e => setNewPerson(prev => ({ ...prev, name: e.target.value }))} />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Relation</label>
+              <Input value={newPerson.relation} onChange={e => setNewPerson(prev => ({ ...prev, relation: e.target.value }))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setAddPersonOpen(false)}>Cancel</Button>
+            <Button type="button" onClick={handleSavePerson}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog open={calculatorOpen} onOpenChange={setCalculatorOpen}>
         <DialogContent className="sm:max-w-xs">
           <DialogHeader>
@@ -683,22 +719,27 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
       <div className={rowClass}>
         <label className={labelClass}>Person (Optional)</label>
 
-        <Select
-          value={editedTransaction.person || 'none'}
-          onValueChange={(value) => handleChange('person', value)}
-        >
-          <SelectTrigger className={cn('w-full text-sm', inputPadding, 'rounded-md border-gray-300 focus:ring-primary')}>
-            <SelectValue placeholder="Select person" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">None</SelectItem>
-            {PEOPLE.map((person) => (
-              <SelectItem key={person} value={person}>
-                {person}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="flex w-full items-center gap-1">
+          <Select
+            value={editedTransaction.person || 'none'}
+            onValueChange={(value) => handleChange('person', value)}
+          >
+            <SelectTrigger className={cn('w-full text-sm', inputPadding, 'rounded-md border-gray-300 focus:ring-primary')}>
+              <SelectValue placeholder="Select person" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">None</SelectItem>
+              {people.map((person) => (
+                <SelectItem key={person} value={person}>
+                  {person}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button type="button" variant="outline" size="icon" onClick={() => setAddPersonOpen(true)}>
+            <Plus className="size-4" />
+          </Button>
+        </div>
       </div>
 
 

--- a/src/components/forms/PersonSelector.tsx
+++ b/src/components/forms/PersonSelector.tsx
@@ -1,9 +1,14 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { UseFormReturn } from 'react-hook-form';
-import { TransactionFormValues, PEOPLE } from './transaction-form-schema';
+import { TransactionFormValues } from './transaction-form-schema';
+import { getPeopleNames, addUserPerson } from '@/lib/people-utils';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
 
 interface PersonSelectorProps {
   form: UseFormReturn<TransactionFormValues>;
@@ -12,35 +17,77 @@ interface PersonSelectorProps {
 const PersonSelector: React.FC<PersonSelectorProps> = ({
   form
 }) => {
+  const [people, setPeople] = useState<string[]>(() => getPeopleNames());
+  const [addOpen, setAddOpen] = useState(false);
+  const [newPerson, setNewPerson] = useState({ name: '', relation: '' });
+
+  const handleSave = () => {
+    if (!newPerson.name.trim()) return;
+    addUserPerson({ name: newPerson.name.trim(), relation: newPerson.relation.trim() || undefined });
+    setPeople(getPeopleNames());
+    form.setValue('person', newPerson.name.trim());
+    setNewPerson({ name: '', relation: '' });
+    setAddOpen(false);
+  };
+
   return (
-    <FormField
-      control={form.control}
-      name="person"
-      render={({ field }) => (
-        <FormItem>
-          <FormLabel>Main Person</FormLabel>
-          <Select
-            value={field.value || "none"}
-            onValueChange={field.onChange}
-          >
-            <FormControl>
-              <SelectTrigger>
-                <SelectValue placeholder="Select person (optional)" />
-              </SelectTrigger>
-            </FormControl>
-            <SelectContent>
-              <SelectItem value="none">None</SelectItem>
-              {PEOPLE.map(person => (
-                <SelectItem key={person} value={person}>
-                  {person}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <FormMessage />
-        </FormItem>
-      )}
-    />
+    <>
+      <FormField
+        control={form.control}
+        name="person"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Main Person</FormLabel>
+            <div className="flex items-center gap-1">
+              <Select
+                value={field.value || 'none'}
+                onValueChange={field.onChange}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select person (optional)" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  {people.map(person => (
+                    <SelectItem key={person} value={person}>
+                      {person}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button type="button" variant="outline" size="icon" onClick={() => setAddOpen(true)}>
+                <Plus className="size-4" />
+              </Button>
+            </div>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Person</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <div>
+              <label className="mb-1 block text-sm font-medium">Name*</label>
+              <Input value={newPerson.name} onChange={e => setNewPerson(prev => ({ ...prev, name: e.target.value }))} />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium">Relation</label>
+              <Input value={newPerson.relation} onChange={e => setNewPerson(prev => ({ ...prev, relation: e.target.value }))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setAddOpen(false)}>Cancel</Button>
+            <Button type="button" onClick={handleSave}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/components/forms/transaction-form-schema.ts
+++ b/src/components/forms/transaction-form-schema.ts
@@ -1,5 +1,6 @@
 
 import { z } from 'zod';
+import { getPeopleNames } from '@/lib/people-utils';
 
 export const transactionFormSchema = z.object({
   title: z.string().min(2, {
@@ -66,4 +67,4 @@ export const CURRENCIES = [
   { code: "AED", name: "UAE Dirham" }
 ];
 
-export const PEOPLE = ["Ahmed", "Marwa", "Youssef", "Salma", "Mazen"];
+export const PEOPLE = getPeopleNames();

--- a/src/lib/categories-data.ts
+++ b/src/lib/categories-data.ts
@@ -1,5 +1,6 @@
 
 import { TransactionType } from '@/types/transaction';
+import { getPeopleNames } from './people-utils';
 
 
 // Fallback in case localStorage isn't ready (optional dev/testing mode)
@@ -35,7 +36,7 @@ export const getSubcategoriesForCategory = (categoryName: string): string[] => {
   const category = getCategoryHierarchy().find(cat => cat.name === categoryName);
   return category ? category.subcategories.map(sub => sub.name) : [];
 };
-export const PEOPLE = ['Ahmed', 'Marwa', 'Youssef', 'Salma', 'Mazen'];
+export const PEOPLE = getPeopleNames();
 
 export const CURRENCIES = ['SAR', 'EGP', 'USD', 'BHD', 'AED'];
 

--- a/src/lib/category-utils.ts
+++ b/src/lib/category-utils.ts
@@ -1,6 +1,7 @@
 import { TransactionType } from '@/types/transaction';
+import { getPeopleNames } from './people-utils';
 
-export const PEOPLE = ['Ahmed', 'Marwa', 'Youssef', 'Salma', 'Mazen'];
+export const PEOPLE = getPeopleNames();
 export const CURRENCIES = ['SAR', 'EGP', 'USD', 'BHD', 'AED'];
 
 type TransactionCategory = {

--- a/src/lib/people-utils.ts
+++ b/src/lib/people-utils.ts
@@ -1,0 +1,43 @@
+export interface Person {
+  name: string;
+  relation?: string;
+  user?: boolean;
+}
+
+const PEOPLE_KEY = 'xpensia_people';
+
+export const DEFAULT_PEOPLE: Person[] = [
+  { name: 'Ahmed' },
+  { name: 'Marwa' },
+  { name: 'Youssef' },
+  { name: 'Salma' },
+  { name: 'Mazen' }
+];
+
+export function getStoredPeople(): Person[] {
+  try {
+    const raw = localStorage.getItem(PEOPLE_KEY);
+    const userPeople: Person[] = raw ? JSON.parse(raw) : [];
+    return [...DEFAULT_PEOPLE, ...userPeople];
+  } catch {
+    return [...DEFAULT_PEOPLE];
+  }
+}
+
+export function getPeopleNames(): string[] {
+  return getStoredPeople().map(p => p.name);
+}
+
+export function addUserPerson(person: Person) {
+  if (!person.name.trim()) return;
+  try {
+    const raw = localStorage.getItem(PEOPLE_KEY);
+    const arr: Person[] = raw ? JSON.parse(raw) : [];
+    if (!arr.some(p => p.name.toLowerCase() === person.name.toLowerCase())) {
+      arr.push({ ...person, user: true });
+      localStorage.setItem(PEOPLE_KEY, JSON.stringify(arr));
+    }
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- load and store people names via `xpensia_people`
- allow adding a person from `PersonSelector`
- show plus icon in manual and SMS forms
- expose helper functions in a new `people-utils` module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6856b84e3cbc8333a6b8271d7909a5ea