### PR TITLE
Add user flag support to storage helpers

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -271,6 +271,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
         name: normalizedCategory,
         type: newCategory.type,
         subcategories: [],
+        user: true,
       };
       hierarchy.push(cat);
     }
@@ -283,6 +284,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
         cat.subcategories.push({
           id: normalizedSubcategory.toLowerCase().replace(/\s+/g, '-'),
           name: normalizedSubcategory,
+          user: true,
         });
       }
     }

--- a/src/components/categories/CategoryManager.tsx
+++ b/src/components/categories/CategoryManager.tsx
@@ -174,6 +174,7 @@ const CategoryManager: React.FC<CategoryManagerProps> = ({
         id: uuidv4(),
         name: values.name,
         parentId: values.parentId,
+        user: true,
         metadata: {
           description: values.description,
           icon: values.icon ? { name: values.icon } : undefined,

--- a/src/lib/account-utils.ts
+++ b/src/lib/account-utils.ts
@@ -25,13 +25,13 @@ export function getStoredAccounts(): Account[] {
   }
 }
 
-export function addUserAccount(account: Account) {
+export function addUserAccount(account: Account, user = true) {
   if (!account.name.trim()) return;
   try {
     const raw = localStorage.getItem(ACCOUNTS_KEY);
     const arr: Account[] = raw ? JSON.parse(raw) : [];
     if (!arr.some(a => a.name.toLowerCase() === account.name.toLowerCase())) {
-      arr.push({ ...account, user: true });
+      arr.push({ ...account, ...(user ? { user: true } : {}) });
       localStorage.setItem(ACCOUNTS_KEY, JSON.stringify(arr));
     }
   } catch {

--- a/src/lib/people-utils.ts
+++ b/src/lib/people-utils.ts
@@ -28,13 +28,13 @@ export function getPeopleNames(): string[] {
   return getStoredPeople().map(p => p.name);
 }
 
-export function addUserPerson(person: Person) {
+export function addUserPerson(person: Person, user = true) {
   if (!person.name.trim()) return;
   try {
     const raw = localStorage.getItem(PEOPLE_KEY);
     const arr: Person[] = raw ? JSON.parse(raw) : [];
     if (!arr.some(p => p.name.toLowerCase() === person.name.toLowerCase())) {
-      arr.push({ ...person, user: true });
+      arr.push({ ...person, ...(user ? { user: true } : {}) });
       localStorage.setItem(PEOPLE_KEY, JSON.stringify(arr));
     }
   } catch {

--- a/src/lib/smart-paste-engine/vendorFallbackUtils.ts
+++ b/src/lib/smart-paste-engine/vendorFallbackUtils.ts
@@ -29,12 +29,13 @@ export function getVendorNames(): string[] {
 
 export function addUserVendor(
   name: string,
-  data: Omit<VendorFallbackData, 'user'>
+  data: Omit<VendorFallbackData, 'user'>,
+  user: boolean = true
 ): void {
   if (!name.trim()) return;
   const vendors = loadVendorFallbacks();
   if (!vendors[name]) {
-    vendors[name] = { ...data, user: true } as VendorFallbackData;
+    vendors[name] = { ...data, ...(user ? { user: true } : {}) } as VendorFallbackData;
     saveVendorFallbacks(vendors);
   }
 }

--- a/src/services/TransactionService.ts
+++ b/src/services/TransactionService.ts
@@ -112,7 +112,8 @@ class TransactionService {
   addCategory(category: Omit<Category, 'id'>): Category {
     const newCategory = {
       ...category,
-      id: uuidv4()
+      id: uuidv4(),
+      user: true
     };
     
     const categories = this.getCategories();

--- a/src/types/transaction.d.ts
+++ b/src/types/transaction.d.ts
@@ -31,4 +31,6 @@ export interface Category {
     icon?: string;
     budget?: number;
   };
+  /** Indicates entry was added by the user */
+  user?: boolean;
 }

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -58,6 +58,8 @@ export interface Category {
   parentId?: string;
   metadata?: CategoryMetadata;
   subcategories?: Category[];
+  /** Indicates entry was added by the user */
+  user?: boolean;
 }
 
 export interface CategoryWithSubcategories extends Category {

--- a/src/utils/storage-utils-fixes.ts
+++ b/src/utils/storage-utils-fixes.ts
@@ -65,6 +65,7 @@ export const validateCategoryForStorage = (category: any): Category => {
   if (category.parentId) validatedCategory.parentId = category.parentId;
   if (category.metadata) validatedCategory.metadata = category.metadata;
   if (category.subcategories) validatedCategory.subcategories = category.subcategories;
+  if (typeof category.user === 'boolean') validatedCategory.user = category.user;
   
   // Ensure ID is present
   if (!validatedCategory.id) {


### PR DESCRIPTION
## Summary
- allow Category to include optional `user` flag
- preserve `user` data in `validateCategoryForStorage`
- add optional `user` parameter when storing vendors, accounts and people
- mark user-created categories in services and components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856bbd416a88333bc0ca646e66e846c