### PR TITLE
Add /settings route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import VendorCategorization from '@/pages/sms/VendorCategorization';
 import VendorMapping from '@/pages/VendorMapping';
 import ReviewDraftTransactions from '@/pages/ReviewDraftTransactions';
 import Analytics from './pages/Analytics';
+import Settings from './pages/Settings';
+import NotFound from './pages/NotFound';
 
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { Capacitor } from '@capacitor/core';
@@ -177,11 +179,13 @@ function AppWrapper() {
       <Route path="/train-model" element={<TrainModel />} />
       <Route path="/build-template" element={<BuildTemplate />} />
       <Route path="/keyword-bank" element={<KeywordBankManager />} />
+      <Route path="/settings" element={<Settings />} />
       <Route path="/process-sms" element={<ProcessSmsMessages />} />
       <Route path="/sms/process-vendors" element={<ProcessVendors />} />
       <Route path="/sms/vendors" element={<VendorCategorization />} />
       <Route path="/vendor-mapping" element={<VendorMapping />} />
       <Route path="/review-draft-transactions" element={<ReviewDraftTransactions />} />
+      <Route path="*" element={<NotFound />} />
     </Routes>
   );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import { Separator } from '@/components/ui/separator';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel } from '@/components/ui/form';
 import { useForm } from 'react-hook-form';
+import { CURRENCIES } from '@/lib/categories-data';
 
 const Settings = () => {
   const { toast } = useToast();
@@ -125,6 +126,18 @@ const Settings = () => {
   const handleNotificationsChange = (checked: boolean) => {
     setNotificationsEnabled(checked);
     updateNotificationSettings(checked);
+  };
+
+  const handleAppearanceSave = () => {
+    updateTheme(theme);
+    updateCurrency(currency);
+    updateLanguage(language);
+    updateNotificationSettings(notificationsEnabled);
+
+    toast({
+      title: "Appearance updated",
+      description: "Your appearance settings have been saved."
+    });
   };
   
   const handleDisplayOptionsChange = () => {
@@ -302,14 +315,11 @@ const Settings = () => {
                       <SelectValue placeholder="Select currency" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="USD">USD ($)</SelectItem>
-                      <SelectItem value="EUR">EUR (€)</SelectItem>
-                      <SelectItem value="GBP">GBP (£)</SelectItem>
-                      <SelectItem value="JPY">JPY (¥)</SelectItem>
-                      <SelectItem value="CAD">CAD (C$)</SelectItem>
-                      <SelectItem value="AUD">AUD (A$)</SelectItem>
-                      <SelectItem value="CNY">CNY (¥)</SelectItem>
-                      <SelectItem value="INR">INR (₹)</SelectItem>
+                      {CURRENCIES.map((code) => (
+                        <SelectItem key={code} value={code}>
+                          {code}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>
@@ -322,10 +332,7 @@ const Settings = () => {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="en">English</SelectItem>
-                      <SelectItem value="es">Español</SelectItem>
-                      <SelectItem value="fr">Français</SelectItem>
-                      <SelectItem value="de">Deutsch</SelectItem>
-                      <SelectItem value="ja">日本語</SelectItem>
+                      <SelectItem value="ar">العربية</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -335,12 +342,18 @@ const Settings = () => {
                     <Label htmlFor="notifications">Notifications</Label>
                     <p className="text-sm text-muted-foreground">Receive alerts and notifications</p>
                   </div>
-                  <Switch 
-                    id="notifications" 
+                <Switch
+                    id="notifications"
                     checked={notificationsEnabled}
                     onCheckedChange={handleNotificationsChange}
                   />
                 </div>
+                <Button
+                  className="w-full mt-4"
+                  onClick={handleAppearanceSave}
+                >
+                  Save Appearance Settings
+                </Button>
               </CardContent>
             </Card>
           </TabsContent>


### PR DESCRIPTION
## Summary
- wire up Settings route in main app
- include fallback NotFound route
- update Settings page
  - load currencies from categories-data
  - only allow English and Arabic languages
  - add Save button for appearance tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d7a8bb388333af38aba3fd7fe23f