### PR TITLE
Fix extra padding in EditTransactionDialog

### DIFF
--- a/src/components/transactions/EditTransactionDialog.tsx
+++ b/src/components/transactions/EditTransactionDialog.tsx
@@ -33,8 +33,9 @@ const EditTransactionDialog: React.FC<EditTransactionDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <ExpenseForm 
+      {/* Reduce top padding for better alignment */}
+      <DialogContent className="sm:max-w-md pt-2">
+        <ExpenseForm
           onSubmit={onSubmit} 
           categories={categories}
           defaultValues={{


### PR DESCRIPTION
## Summary
- reduce top padding around the form inside `EditTransactionDialog`

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6856db1faa348333946db1d9713d1ee6