### PR TITLE
Fix missing React imports

### DIFF
--- a/src/hooks/useTransactionsState.tsx
+++ b/src/hooks/useTransactionsState.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { Transaction } from '@/types/transaction';
 import { useTransactionsCrud } from './transactions/useTransactionsCrud';


### PR DESCRIPTION
## Summary
- update `useTransactionsState` hook to import `useState` and `useEffect`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6856e0b7e0c08333972e58833a899f48