### PR TITLE
Fix transaction order when adding new entries

### DIFF
--- a/src/context/TransactionContext.tsx
+++ b/src/context/TransactionContext.tsx
@@ -33,14 +33,14 @@ export const TransactionProvider: React.FC<{ children: ReactNode }> = ({ childre
       id: transaction.id || `transaction-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
       source: transaction.source || 'manual'
     }));
-    
+
     // Update state
     setTransactions(prevTransactions => {
-      const updatedTransactions = [...prevTransactions, ...validTransactions];
-      
+      const updatedTransactions = [...validTransactions, ...prevTransactions];
+
       // Store in local storage
       storeTransactions(updatedTransactions);
-      
+
       return updatedTransactions;
     });
   };
@@ -55,11 +55,11 @@ export const TransactionProvider: React.FC<{ children: ReactNode }> = ({ childre
     
     // Update state
     setTransactions(prevTransactions => {
-      const updatedTransactions = [...prevTransactions, validTransaction];
-      
+      const updatedTransactions = [validTransaction, ...prevTransactions];
+
       // Store in local storage
       storeTransactions(updatedTransactions);
-      
+
       return updatedTransactions;
     });
   };


### PR DESCRIPTION
## Summary
- ensure newly added transactions appear at top of transaction list
- keep multi-transaction inserts in same order when prepending

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68570aa3abfc833383a36aac6218dda7