### PR TITLE
Apply vendor mapping

### DIFF
--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -1,6 +1,6 @@
 import { Transaction, TransactionType } from '@/types/transaction';
 import { nanoid } from 'nanoid';
-import { parseSmsMessage } from './structureParser';
+import { parseSmsMessage, applyVendorMapping } from './structureParser';
 import { loadKeywordBank } from './keywordBankUtils';
 import { getAllTemplates } from './templateUtils';
 import {
@@ -26,6 +26,10 @@ export function parseAndInferTransaction(
 ): ParsedTransactionResult {
   const parsed = parseSmsMessage(rawMessage);
 
+  const vendor = applyVendorMapping(
+    parsed.inferredFields.vendor || parsed.directFields.vendor || ''
+  );
+
   const transaction: Transaction = {
     id: nanoid(),
     amount: parseFloat(parsed.directFields.amount || '0'),
@@ -34,7 +38,7 @@ export function parseAndInferTransaction(
     type: (parsed.inferredFields.type as TransactionType) || 'expense',
     category: parsed.inferredFields.category || 'Uncategorized',
     subcategory: parsed.inferredFields.subcategory || 'none',
-    vendor: parsed.inferredFields.vendor || parsed.directFields.vendor || '',
+    vendor,
     fromAccount:
       parsed.directFields.fromAccount ||
       parsed.inferredFields.fromAccount ||

--- a/src/lib/smart-paste-engine/structureParser.ts
+++ b/src/lib/smart-paste-engine/structureParser.ts
@@ -108,7 +108,7 @@ if (directFields['date']) {
 
 
 
-function applyVendorMapping(vendor: string): string {
+export function applyVendorMapping(vendor: string): string {
   const map = JSON.parse(localStorage.getItem('xpensia_vendor_map') || '{}');
   return map[vendor] || vendor;
 }


### PR DESCRIPTION
## Summary
- export `applyVendorMapping`
- use `applyVendorMapping` when building parsed transactions

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857ee4db068833389cf79c202a4f71f