### PR TITLE
Rename SMS parsers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { StatusBar, Style } from '@capacitor/status-bar';
 import { Capacitor } from '@capacitor/core';
 import { v4 as uuidv4 } from 'uuid';
 import { Transaction } from '@/types/transaction';
-import { parseSmsMessage } from '@/lib/sms-parser';
+import { parseLegacySms } from '@/lib/sms-parser';
 import { isFinancialTransactionMessage } from '@/lib/smart-paste-engine/messageFilter';
 import { App as CapacitorApp } from '@capacitor/app';
 import { LocalNotifications } from '@capacitor/local-notifications';
@@ -92,7 +92,7 @@ function AppWrapper() {
                 return;
               }
 
-              const parsed = parseSmsMessage(body, sender);
+              const parsed = parseLegacySms(body, sender);
 
               const txn: Transaction = {
                 id: uuidv4(),

--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -9,7 +9,7 @@ import { Label } from './ui/label';
 import DetectedTransactionCard from './smart-paste/DetectedTransactionCard';
 import ErrorAlert from './smart-paste/ErrorAlert';
 import NoTransactionMessage from './smart-paste/NoTransactionMessage';
-import { parseSmsMessage } from '@/lib/smart-paste-engine/structureParser';
+import { parseStructuredSms } from '@/lib/smart-paste-engine/structureParser';
 import { parseAndInferTransaction } from '@/lib/smart-paste-engine/parseAndInferTransaction';
 import { isFinancialTransactionMessage } from '@/lib/smart-paste-engine/messageFilter';
 
@@ -47,7 +47,7 @@ const SmartPaste = ({ senderHint, onTransactionsDetected }: SmartPasteProps) => 
     }
 
     try {
-      const parsed = parseSmsMessage(text);
+      const parsed = parseStructuredSms(text);
       if (parsed.matched) {
         const bank =
           parsed.inferredFields.vendor ||

--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -1,6 +1,6 @@
 import { Transaction, TransactionType } from '@/types/transaction';
 import { nanoid } from 'nanoid';
-import { parseSmsMessage, applyVendorMapping } from './structureParser';
+import { parseStructuredSms, applyVendorMapping } from './structureParser';
 import { loadKeywordBank } from './keywordBankUtils';
 import { getAllTemplates } from './templateUtils';
 import {
@@ -14,7 +14,7 @@ export interface ParsedTransactionResult {
   transaction: Transaction;
   confidence: number;
   origin: 'template' | 'structure' | 'ml' | 'fallback';
-  parsed: ReturnType<typeof parseSmsMessage>;
+  parsed: ReturnType<typeof parseStructuredSms>;
 }
 
 /**
@@ -24,7 +24,7 @@ export function parseAndInferTransaction(
   rawMessage: string,
   senderHint?: string
 ): ParsedTransactionResult {
-  const parsed = parseSmsMessage(rawMessage);
+  const parsed = parseStructuredSms(rawMessage);
 
   const vendor = applyVendorMapping(
     parsed.inferredFields.vendor || parsed.directFields.vendor || ''

--- a/src/lib/smart-paste-engine/smsParser.ts
+++ b/src/lib/smart-paste-engine/smsParser.ts
@@ -40,7 +40,7 @@ function normalizeDate(value: string): string | null {
 }
 
 
-export function parseSmsMessage(message: string): TransactionDraft | null {
+export function parseSimpleSms(message: string): TransactionDraft | null {
   if (!message) return null;
 
   let amount = 0;

--- a/src/lib/smart-paste-engine/structureParser.ts
+++ b/src/lib/smart-paste-engine/structureParser.ts
@@ -31,7 +31,7 @@ export function normalizeDate(dateStr: string): string | undefined {
 }
 
 
-export function parseSmsMessage(rawMessage: string) {
+export function parseStructuredSms(rawMessage: string) {
   console.log('[SmartPaste] Step 1: Received raw message:', rawMessage);
 	if (!rawMessage) {
     throw new Error('Empty message passed to extractTemplateStructure');

--- a/src/lib/sms-parser.ts
+++ b/src/lib/sms-parser.ts
@@ -166,7 +166,7 @@ function getUserPreferredCurrency(): SupportedCurrency {
 /**
  * Parse an SMS message to extract transaction details
  */
-export function parseSmsMessage(message: string, sender: string): ParsedTransaction | null {
+export function parseLegacySms(message: string, sender: string): ParsedTransaction | null {
   // Try each transaction pattern until one matches
   for (const pattern of TRANSACTION_PATTERNS) {
     const matches = message.match(pattern.regex);

--- a/src/services/SmsProcessingService.ts
+++ b/src/services/SmsProcessingService.ts
@@ -1,4 +1,4 @@
-import { parseSmsMessage } from '@/lib/smart-paste-engine/structureParser';
+import { parseStructuredSms } from '@/lib/smart-paste-engine/structureParser';
 import { Transaction } from '@/types/transaction';
 
 interface SmsEntry {
@@ -16,7 +16,7 @@ export function processSmsEntries(entries: SmsEntry[]): Transaction[] {
   return entries.map(entry => {
     try {
       // Use the smart paste engine to parse the SMS message
-      const parsedResult = parseSmsMessage(entry.message);
+      const parsedResult = parseStructuredSms(entry.message);
 
       // Extract relevant information from the parsed result
       const { directFields, inferredFields } = parsedResult;


### PR DESCRIPTION
## Summary
- rename `parseSmsMessage` in `structureParser.ts` to `parseStructuredSms`
- update references in SmartPaste and SmsProcessingService
- rename `parseSmsMessage` in `sms-parser.ts` to `parseLegacySms`
- adjust `parseAndInferTransaction` for the new structured parser
- rename simple SMS parser to `parseSimpleSms`
- update App.tsx to use `parseLegacySms`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857efa1d9f48333a0725f6caf0eaf71