### PR TITLE
Honor custom type keywords in message filter

### DIFF
--- a/src/lib/smart-paste-engine/__tests__/messageFilter.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/messageFilter.test.ts
@@ -1,0 +1,39 @@
+import { isFinancialTransactionMessage } from '../messageFilter';
+
+// Simple in-memory localStorage mock
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return store[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+globalThis.localStorage = localStorageMock as any;
+
+test('detects financial message with custom keyword', () => {
+  localStorage.clear();
+  localStorage.setItem(
+    'xpensia_type_keywords',
+    JSON.stringify([{ keyword: 'foobar', type: 'expense' }])
+  );
+
+  const text = 'Foobar purchase of 100 SAR on 01/01/2024';
+  expect(isFinancialTransactionMessage(text)).toBe(true);
+});
+
+test('fails detection without custom keyword', () => {
+  localStorage.clear();
+  const text = 'Foobar purchase of 100 SAR on 01/01/2024';
+  expect(isFinancialTransactionMessage(text)).toBe(false);
+});

--- a/src/lib/smart-paste-engine/messageFilter.ts
+++ b/src/lib/smart-paste-engine/messageFilter.ts
@@ -6,7 +6,14 @@ export function isFinancialTransactionMessage(text: string): boolean {
     if (raw) {
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) {
-        storedKeywords = parsed;
+        storedKeywords = parsed
+          .map((entry: any) => {
+            if (typeof entry === 'string') return entry;
+            if (entry && typeof entry.keyword === 'string') return entry.keyword;
+            console.warn('[MessageFilter] Invalid keyword entry:', entry);
+            return null;
+          })
+          .filter((k: string | null): k is string => !!k);
       } else {
         console.warn('[MessageFilter] Invalid xpensia_type_keywords format:', parsed);
       }


### PR DESCRIPTION
## Summary
- use the `keyword` property in `xpensia_type_keywords`
- fall back to the provided keywords in message filter
- add unit tests covering custom keyword detection

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6857f09cf1b08333858e4275c170f5f5