### PR TITLE
Apply vendor mapping earlier

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -18,6 +18,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import vendorData from '@/data/ksa_all_vendors_clean_final.json';
 import { loadVendorFallbacks, addUserVendor } from '@/lib/smart-paste-engine/vendorFallbackUtils';
+import { applyVendorMapping } from '@/lib/smart-paste-engine/structureParser';
 
 interface TransactionEditFormProps {
   transaction?: Transaction;
@@ -69,11 +70,6 @@ function toISOFormat(input: string): string {
   return isNaN(fallback.getTime()) ? '' : fallback.toISOString().split('T')[0];
 }
 
-function remapVendor(vendor?: string): string {
-  if (!vendor) return '';
-  const map = JSON.parse(localStorage.getItem('xpensia_vendor_map') || '{}');
-  return map[vendor] && map[vendor].trim() !== '' ? map[vendor] : vendor;
-}
 
 const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
   transaction,
@@ -138,7 +134,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
 
   const [editedTransaction, setEditedTransaction] = useState<Transaction>(() => {
     if (transaction) {
-      const mappedVendor = remapVendor(transaction.vendor);
+      const mappedVendor = applyVendorMapping(transaction.vendor);
       const displayDate = transaction.date ? toISOFormat(transaction.date) : '';
       const rawMessage = (transaction as any).rawMessage || transaction.details?.rawMessage || '';
 

--- a/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
+++ b/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
@@ -4,6 +4,7 @@ import { extractTemplateStructure, getAllTemplates, saveNewTemplate, loadTemplat
 import { loadKeywordBank, saveKeywordBank } from './keywordBankUtils';
 import { storeTransaction } from '@/utils/storage-utils';
 import { toast } from '@/components/ui/use-toast';
+import { applyVendorMapping } from './structureParser';
 
 interface SaveOptions {
   rawMessage?: string;
@@ -32,7 +33,8 @@ export function saveTransactionWithLearning(
   const newTransaction: Transaction = {
     ...transaction,
     id: transaction.id || uuidv4(),
-    source: transaction.source || 'manual'
+    source: transaction.source || 'manual',
+    vendor: applyVendorMapping(transaction.vendor)
   };
 
   if (isNew) {
@@ -62,7 +64,9 @@ export function saveTransactionWithLearning(
     });
 
     // Keyword Bank Mapping
-    const keyword = placeholders?.vendor?.toLowerCase() || newTransaction.vendor.toLowerCase();
+    const keyword = applyVendorMapping(
+      placeholders?.vendor || newTransaction.vendor
+    ).toLowerCase();
     const bank = loadKeywordBank();
     const existing = bank.find(k => k.keyword === keyword);
 

--- a/src/lib/smart-paste-engine/structureParser.ts
+++ b/src/lib/smart-paste-engine/structureParser.ts
@@ -82,14 +82,20 @@ export function parseStructuredSms(rawMessage: string) {
     directFields[key] = value;
   });
 }
-// Normalize known field names like 'date'
-if (directFields['date']) {
-  const normalized = normalizeDate(directFields['date']);
-  if (normalized) {
-    directFields['date'] = normalized;
-    console.log('[SmartPaste] Normalized date:', directFields['date']);
+
+  // Normalize known field names like 'date'
+  if (directFields['date']) {
+    const normalized = normalizeDate(directFields['date']);
+    if (normalized) {
+      directFields['date'] = normalized;
+      console.log('[SmartPaste] Normalized date:', directFields['date']);
+    }
   }
-}
+
+  // Apply saved vendor mappings before running inference
+  if (directFields['vendor']) {
+    directFields['vendor'] = applyVendorMapping(directFields['vendor']);
+  }
 
   const inferred = inferIndirectFields(rawMessage, directFields);
   console.log('[SmartPaste] Step 5: Inferred fields:', inferred);
@@ -108,6 +114,9 @@ if (directFields['date']) {
 
 
 
+// Utility to normalize vendor names based on user-maintained mappings.
+// The mapping is stored in localStorage under `xpensia_vendor_map` and is
+// consulted by the parser and forms for consistent vendor labels.
 export function applyVendorMapping(vendor: string): string {
   const map = JSON.parse(localStorage.getItem('xpensia_vendor_map') || '{}');
   return map[vendor] || vendor;


### PR DESCRIPTION
## Summary
- map vendor data immediately in the message parser
- keep vendor mapping consistent when saving transactions
- reuse the same vendor mapping helper in edit forms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857f5581c60833392c4c555a213db1f