### PR TITLE
Validate amount parsing

### DIFF
--- a/src/lib/smart-paste-engine/__tests__/parseAndInferTransaction.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/parseAndInferTransaction.test.ts
@@ -1,0 +1,56 @@
+import { mock, test, expect } from 'bun:test';
+
+// Simple in-memory localStorage mock
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return store[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+globalThis.localStorage = localStorageMock as any;
+
+mock.module('../structureParser', () => ({
+  parseStructuredSms: (msg: string) => {
+    const base = {
+      rawMessage: msg,
+      template: '',
+      templateHash: '',
+      matched: false,
+      inferredFields: {},
+      defaultValues: {},
+    };
+    if (msg === 'empty') {
+      return { ...base, directFields: { amount: '', currency: 'SAR', date: '' } };
+    }
+    if (msg === 'invalid') {
+      return { ...base, directFields: { amount: 'abc', currency: 'SAR', date: '' } };
+    }
+    return { ...base, directFields: { amount: '123', currency: 'SAR', date: '' } };
+  },
+  applyVendorMapping: (v: string) => v,
+}));
+
+mock.module('nanoid', () => ({ nanoid: () => 'id' }));
+mock.module('../templateUtils', () => ({ getAllTemplates: () => [] }));
+
+const { parseAndInferTransaction } = await import('../parseAndInferTransaction');
+
+test('defaults amount to 0 when placeholder is empty or malformed', () => {
+  const empty = parseAndInferTransaction('empty');
+  expect(empty.transaction.amount).toBe(0);
+
+  const invalid = parseAndInferTransaction('invalid');
+  expect(invalid.transaction.amount).toBe(0);
+});

--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -30,9 +30,10 @@ export function parseAndInferTransaction(
     parsed.inferredFields.vendor || parsed.directFields.vendor || ''
   );
 
+  const parsedAmount = parseFloat(parsed.directFields.amount || '');
   const transaction: Transaction = {
     id: nanoid(),
-    amount: parseFloat(parsed.directFields.amount || '0'),
+    amount: isNaN(parsedAmount) ? 0 : parsedAmount,
     currency: parsed.directFields.currency || 'SAR',
     date: parsed.directFields.date || '',
     type: (parsed.inferredFields.type as TransactionType) || 'expense',


### PR DESCRIPTION
## Summary
- guard against invalid amount parsing in `parseAndInferTransaction`
- add regression test for empty or malformed amount placeholders

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6857f6b625e88333972d2714923e972b