### PR TITLE
Fix layout for SMS mapping pages

### DIFF
--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -7,7 +7,6 @@ import { Capacitor } from '@capacitor/core';
 import { useNavigate } from 'react-router-dom';
 import { extractVendorName, inferIndirectFields } from '@/lib/smart-paste-engine/suggestionEngine';
 import Layout from '@/components/Layout';
-import { ArrowLeft } from 'lucide-react';
 import { isFinancialTransactionMessage } from '@/lib/smart-paste-engine/messageFilter';
 
 interface ProcessedSmsEntry extends SmsEntry {
@@ -156,51 +155,44 @@ const handleReadSms = async () => {
   };
 
   return (
-    <Layout>
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
-          <Button variant="outline" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <h1 className="text-xl sm:text-2xl font-bold">Process SMS Messages</h1>
-        </div>
-      </div>
+    <Layout showBack withPadding={false} fullWidth>
+      <div className="px-1">
+        <Button className="w-full mb-4" onClick={handleReadSms} disabled={loading}>
+          {loading ? 'Reading...' : 'Read SMS'}
+        </Button>
 
-      <Button className="w-full mb-4" onClick={handleReadSms} disabled={loading}>
-        {loading ? 'Reading...' : 'Read SMS'}
-      </Button>
+        {senders.length > 0 && (
+          <div className="mb-6">
+            <h2 className="text-lg font-semibold mb-2">Select Senders:</h2>
+            {senders.map((sender) => (
+              <label key={sender} className="flex items-center mb-2">
+                <input
+                  type="checkbox"
+                  checked={selectedSenders.includes(sender)}
+                  onChange={() => toggleSenderSelect(sender)}
+                  className="mr-2"
+                />
+                {sender}
+              </label>
+            ))}
 
-      {senders.length > 0 && (
-        <div className="mb-6">
-          <h2 className="text-lg font-semibold mb-2">Select Senders:</h2>
-          {senders.map((sender) => (
-            <label key={sender} className="flex items-center mb-2">
-              <input
-                type="checkbox"
-                checked={selectedSenders.includes(sender)}
-                onChange={() => toggleSenderSelect(sender)}
-                className="mr-2"
-              />
-              {sender}
-            </label>
+            <Button className="mt-4 w-full" onClick={handleProceed}>
+              Proceed to Vendor Mapping
+            </Button>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {filteredMessages
+            .filter((msg): msg is ProcessedSmsEntry => !!msg && typeof msg.sender === 'string')
+            .map((msg, index) => (
+              <Card key={index} className="p-[var(--card-padding)]">
+                <p><strong>From:</strong> {msg.sender}</p>
+                <p><strong>Date:</strong> {new Date(msg.date).toLocaleString()}</p>
+                <p><strong>Message:</strong> {msg.message}</p>
+              </Card>
           ))}
-
-          <Button className="mt-4 w-full" onClick={handleProceed}>
-            Proceed to Vendor Mapping
-          </Button>
         </div>
-      )}
-
-      <div className="space-y-4">
-        {filteredMessages
-          .filter((msg): msg is ProcessedSmsEntry => !!msg && typeof msg.sender === 'string')
-          .map((msg, index) => (
-            <Card key={index} className="p-[var(--card-padding)]">
-              <p><strong>From:</strong> {msg.sender}</p>
-              <p><strong>Date:</strong> {new Date(msg.date).toLocaleString()}</p>
-              <p><strong>Message:</strong> {msg.message}</p>
-            </Card>
-        ))}
       </div>
     </Layout>
   );

--- a/src/pages/ReviewDraftTransactions.tsx
+++ b/src/pages/ReviewDraftTransactions.tsx
@@ -9,7 +9,6 @@ import { saveTransactionWithLearning } from '@/lib/smart-paste-engine/saveTransa
 import { generateDefaultTitle } from '@/components/TransactionEditForm';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Layout from '@/components/Layout';
-import { ArrowLeft } from 'lucide-react';
 import { getCategoriesForType, getSubcategoriesForCategory} from '@/lib/categories-data';
 import { useTransactions } from '@/context/TransactionContext';
 
@@ -158,15 +157,8 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
   };
 
   return (
-    <Layout>
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
-          <Button variant="outline" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <h1 className="text-xl sm:text-2xl font-bold">Review SMS Transactions</h1>
-        </div>
-      </div>
+    <Layout showBack withPadding={false} fullWidth>
+      <div className="px-1">
 
       {transactions.map((txn, index) => (
         <Card key={index} className="p-[var(--card-padding)] mb-4">
@@ -201,9 +193,10 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
         </Card>
       ))}
 
-      <Button className="w-full mt-4" onClick={handleSave}>
-        Save All
-      </Button>
+        <Button className="w-full mt-4" onClick={handleSave}>
+          Save All
+        </Button>
+      </div>
     </Layout>
   );
 };

--- a/src/pages/VendorMapping.tsx
+++ b/src/pages/VendorMapping.tsx
@@ -6,7 +6,6 @@ import { useToast } from '@/components/ui/use-toast';
 import { findClosestFallbackMatch } from '@/lib/smart-paste-engine/suggestionEngine';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Layout from '@/components/Layout';
-import { ArrowLeft } from 'lucide-react';
 
 interface VendorMappingEntry {
   vendor: string;
@@ -102,28 +101,20 @@ const VendorMapping: React.FC = () => {
   };
 
   return (
-    <Layout>
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
-          <Button variant="outline" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <h1 className="text-xl sm:text-2xl font-bold">Vendor Mapping</h1>
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        {vendors.map((vendor, index) => (
-          <Card key={vendor.vendor} className="p-[var(--card-padding)]">
-            <div className="mb-2">
-              <label className="block mb-1 font-semibold">Vendor:</label>
-              <input
-                type="text"
-                value={vendor.updatedVendor}
-                onChange={e => handleVendorChange(index, 'updatedVendor', e.target.value)}
-                className="w-full border rounded p-2"
-              />
-            </div>
+    <Layout showBack withPadding={false} fullWidth>
+      <div className="px-1">
+        <div className="space-y-4">
+          {vendors.map((vendor, index) => (
+            <Card key={vendor.vendor} className="p-[var(--card-padding)]">
+              <div className="mb-2">
+                <label className="block mb-1 font-semibold">Vendor:</label>
+                <input
+                  type="text"
+                  value={vendor.updatedVendor}
+                  onChange={e => handleVendorChange(index, 'updatedVendor', e.target.value)}
+                  className="w-full border rounded p-2"
+                />
+              </div>
 
             <div className="mb-2">
               <label className="block mb-1 font-semibold">Category:</label>
@@ -154,9 +145,10 @@ const VendorMapping: React.FC = () => {
         ))}
       </div>
 
-      <Button className="mt-6 w-full" onClick={handleConfirm}>
-        Confirm
-      </Button>
+        <Button className="mt-6 w-full" onClick={handleConfirm}>
+          Confirm
+        </Button>
+      </div>
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary
- remove manual back headers and update layout options for SMS-related pages
- wrap page content in a padded container for consistency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858089697b88333b007988cb7cd4b7a