### PR TITLE
Improve SMS sender selection UI

### DIFF
--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -157,23 +157,36 @@ const handleReadSms = async () => {
   return (
     <Layout showBack withPadding={false} fullWidth>
       <div className="px-1 space-y-[var(--card-gap)]">
-        <Button className="w-full" onClick={handleReadSms} disabled={loading}>
+        <Button
+          variant="default"
+          className="w-full"
+          onClick={handleReadSms}
+          disabled={loading}
+        >
           {loading ? 'Reading...' : 'Read SMS'}
         </Button>
 
         {senders.length > 0 && (
           <Card className="p-[var(--card-padding)] space-y-2">
             <h2 className="text-lg font-semibold">Select Senders:</h2>
+            <p className="text-sm text-muted-foreground">
+              Select which senders to include:
+            </p>
             {senders.map((sender) => (
-              <label key={sender} className="flex items-center">
-                <input
-                  type="checkbox"
-                  checked={selectedSenders.includes(sender)}
-                  onChange={() => toggleSenderSelect(sender)}
-                  className="mr-2"
-                />
-                {sender}
-              </label>
+              <div
+                key={sender}
+                className="p-2 rounded-md mb-2 border"
+              >
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={selectedSenders.includes(sender)}
+                    onChange={() => toggleSenderSelect(sender)}
+                    className="mr-2"
+                  />
+                  {sender}
+                </label>
+              </div>
             ))}
 
             <Button className="w-full" onClick={handleProceed}>


### PR DESCRIPTION
## Summary
- update UI on ProcessSmsMessages sender selection screen
- wrap each sender checkbox in styled container
- add helper text above checkbox list
- ensure "Read SMS" button uses default variant

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: ENETUNREACH when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68583119e51c833388e9336479977db5