### PR TITLE
Fix bottom spacing on mobile pages

### DIFF
--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -231,7 +231,7 @@ const handleReadSms = async () => {
 
   return (
     <Layout showBack withPadding={false} fullWidth>
-      <div className="px-1 space-y-[var(--card-gap)]">
+      <div className="px-1 space-y-[var(--card-gap)] pb-[var(--header-height)]">
         <Button
           variant="default"
           className="w-full"

--- a/src/pages/ReviewDraftTransactions.tsx
+++ b/src/pages/ReviewDraftTransactions.tsx
@@ -158,7 +158,7 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
 
   return (
     <Layout showBack withPadding={false} fullWidth>
-      <div className="px-1 space-y-[var(--card-gap)]">
+      <div className="px-1 space-y-[var(--card-gap)] pb-[var(--header-height)]">
         <div className="space-y-[var(--card-gap)]">
           {transactions.map((txn, index) => (
             <Card key={index} className="w-full">

--- a/src/pages/VendorMapping.tsx
+++ b/src/pages/VendorMapping.tsx
@@ -118,7 +118,7 @@ const VendorMapping: React.FC = () => {
 
   return (
     <Layout showBack withPadding={false} fullWidth>
-      <div className="px-1 pb-24">
+      <div className="px-1 pb-[var(--header-height)]">
         <Accordion type="multiple" className="space-y-[var(--card-gap)]">
           {vendors.map((vendor, index) => (
             <AccordionItem key={vendor.vendor} value={vendor.vendor}>


### PR DESCRIPTION
## Summary
- ensure mobile pages with bottom buttons have space above navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685835c80d50833391cf35e2b4af8c1f