### PR TITLE
Expose SMS read limit

### DIFF
--- a/capacitor-sms-reader/android/src/main/java/com/xpensia/plugins/smsreader/SmsReaderPlugin.java
+++ b/capacitor-sms-reader/android/src/main/java/com/xpensia/plugins/smsreader/SmsReaderPlugin.java
@@ -61,7 +61,7 @@ public class SmsReaderPlugin extends Plugin {
 
         String startDate = call.getString("startDate");
         String endDate = call.getString("endDate");
-        Integer limit = call.getInt("limit", 100);
+        Integer limit = call.getInt("limit");
         JSArray senders = call.getArray("senders");
 
         JSObject ret = new JSObject();
@@ -85,12 +85,17 @@ public class SmsReaderPlugin extends Plugin {
             }
 
             // Query the SMS content provider
+            String sortOrder = Telephony.Sms.DATE + " DESC";
+            if (limit != null && limit > 0) {
+                sortOrder += " LIMIT " + limit;
+            }
+
             Cursor cursor = getContext().getContentResolver().query(
                     Telephony.Sms.Inbox.CONTENT_URI,
                     projection,
                     selection,
                     selectionArgs,
-                    Telephony.Sms.DATE + " DESC LIMIT " + limit
+                    sortOrder
             );
 
             if (cursor != null && cursor.moveToFirst()) {

--- a/src/services/SmsReaderService.ts
+++ b/src/services/SmsReaderService.ts
@@ -75,6 +75,7 @@ export class SmsReaderService {
     try {
       const result = await SmsReader.readSmsMessages({
         ...options,
+        limit: options.limit ?? 10000,
         startDate: String(startDate),
         endDate: String(endDate),
       });


### PR DESCRIPTION
## Summary
- let the JS side specify `limit` in `SmsReaderPlugin.java`
- request up to 10k messages in `SmsReaderService`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --no-audit --no-fund` *(fails: connect ENETUNREACH github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68583728f06883339c51b175a74c4926