### PR TITLE
Refine padding on SMS & vendor pages

### DIFF
--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -231,7 +231,7 @@ const handleReadSms = async () => {
 
   return (
     <Layout showBack withPadding={false} fullWidth>
-      <div className="px-1 space-y-[var(--card-gap)] pb-[var(--header-height)]">
+      <div className="px-1 pt-4 space-y-[var(--card-gap)] pb-[var(--header-height)]">
         <Button
           variant="default"
           className="w-full"
@@ -299,7 +299,7 @@ const handleReadSms = async () => {
                     </Button>
                   </div>
                   {displayed.map((msg, idx) => (
-                    <div key={idx} className="border rounded p-2 space-y-1">
+                    <div key={idx} className="border rounded bg-card p-2 space-y-1">
                       <div className="flex items-center justify-between text-xs text-muted-foreground">
                         <span>{new Date(msg.date).toLocaleString()}</span>
                         <Badge variant={msg.matchedKeyword ? 'success' : 'outline'}>

--- a/src/pages/VendorMapping.tsx
+++ b/src/pages/VendorMapping.tsx
@@ -118,7 +118,7 @@ const VendorMapping: React.FC = () => {
 
   return (
     <Layout showBack withPadding={false} fullWidth>
-      <div className="px-1 pb-[var(--header-height)]">
+      <div className="px-1 pt-4 pb-[var(--header-height)] space-y-[var(--card-gap)]">
         <Accordion type="multiple" className="space-y-[var(--card-gap)]">
           {vendors.map((vendor, index) => (
             <AccordionItem key={vendor.vendor} value={vendor.vendor}>
@@ -179,7 +179,7 @@ const VendorMapping: React.FC = () => {
         </Accordion>
       </div>
 
-      <div className="fixed bottom-16 left-0 right-0 px-4 pb-4">
+      <div className="fixed bottom-16 left-0 right-0 px-4 pb-4 bg-background/90">
         <div className="flex gap-2">
           <Button className="flex-1" onClick={handleConfirm}>Save</Button>
           <Button variant="outline" className="flex-1" onClick={() => navigate(-1)}>


### PR DESCRIPTION
## Summary
- tweak SMS reader page spacing
- match padding on vendor mapping page
- make bottom bar theme-aware

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68583782fd4883339d941b8a6b0a3535