### PR TITLE
Update Import SMS intro and rename nav items

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,7 @@ const routeTitleMap: Record<string, string> = {
   '/dashboard': 'Dashboard',
   '/transactions': 'Transactions',
   '/analytics': 'Analytics',
-  '/process-sms': 'Process SMS',
+  '/process-sms': 'Import SMS',
   '/settings': 'Settings',
   '/profile': 'Profile',
 };
@@ -46,7 +46,7 @@ const Header = ({ className, showNavigation = true }: HeaderProps) => {
     { title: 'Dashboard', path: '/dashboard', icon: Home, description: 'Overview of your finances' },
     { title: 'Analytics', path: '/analytics', icon: PieChart, description: 'Detailed reports and charts' },
     { title: 'Transactions', path: '/transactions', icon: List, description: 'View and manage your transactions' },
-    { title: 'Process SMS', path: '/process-sms', icon: MessageSquare, description: 'Import transactions from SMS' },
+    { title: 'Import SMS', path: '/process-sms', icon: MessageSquare, description: 'Import transactions from SMS' },
     { title: 'Settings', path: '/settings', icon: Settings, description: 'Configure app preferences' },
     { title: 'Profile', path: '/profile', icon: User, description: 'Manage your profile' },
   ];

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -27,7 +27,7 @@ const MobileNav: React.FC = () => {
     { name: 'Transactions', path: '/transactions', icon: <BarChart3 size={20} /> },
     { name: 'Analytics', path: '/analytics', icon: <LineChart size={20} /> },
     { name: 'Paste & Parse', path: '/import-transactions', icon: <Upload size={20} /> },
-    { name: 'SMS Processing', path: '/process-sms', icon: <MessageSquare size={20} /> },
+    { name: 'Import SMS', path: '/process-sms', icon: <MessageSquare size={20} /> },
     { name: 'Profile', path: '/profile', icon: <User size={20} /> },
     { name: 'Settings', path: '/settings', icon: <Settings size={20} /> },
     { name: 'Train Model', path: '/train-model', icon: <School size={20} /> }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ const Sidebar: React.FC = () => {
     { name: 'Transactions', path: '/transactions', icon: <BarChart3 size={20} /> },
     { name: 'Analytics', path: '/analytics', icon: <LineChart size={20} /> },
     { name: 'Paste & Parse', path: '/import-transactions', icon: <Upload size={20} /> },
-    { name: 'SMS Processing', path: '/process-sms', icon: <MessageSquare size={20} /> },
+    { name: 'Import SMS', path: '/process-sms', icon: <MessageSquare size={20} /> },
     { name: 'Profile', path: '/profile', icon: <User size={20} /> },
     { name: 'Settings', path: '/settings', icon: <Settings size={20} /> },
 	{ name: 'Keyword Bank', path: '/keyword-bank', icon: <Tag size={20} /> },

--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -47,11 +47,11 @@ export const getNavItems = () => [
     icon: 'Upload',
     description: 'Import transactions from SMS or paste'
   },
-  { 
-    title: 'Process SMS', 
-    path: '/process-sms', 
-    icon: 'MessageSquare', 
-    description: 'Import transactions from SMS' 
+  {
+    title: 'Import SMS',
+    path: '/process-sms',
+    icon: 'MessageSquare',
+    description: 'Import transactions from SMS'
   },
   {
     title: 'Settings',

--- a/src/components/wireframes/WireframeHeader.tsx
+++ b/src/components/wireframes/WireframeHeader.tsx
@@ -17,7 +17,7 @@ const routeTitleMap: Record<string, string> = {
   '/dashboard': 'Dashboard',
   '/transactions': 'Transactions',
   '/analytics': 'Analytics',
-  '/process-sms': 'Process SMS',
+  '/process-sms': 'Import SMS',
   '/settings': 'Settings',
   '/profile': 'Profile',
   '/sms-providers': 'SMS Providers',

--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -232,6 +232,14 @@ const handleReadSms = async () => {
   return (
     <Layout showBack withPadding={false} fullWidth>
       <div className="px-1 pt-4 space-y-[var(--card-gap)] pb-[var(--header-height)]">
+        <div className="text-center">
+          <h2 className="text-lg font-semibold flex items-center justify-center gap-1 mb-1">
+            <span>📩</span> Import from Bank SMS
+          </h2>
+          <p className="text-sm text-muted-foreground px-2 mb-2">
+            Choose your SMS senders and tap <b>Read SMS</b> to begin importing transactions.
+          </p>
+        </div>
         <Button
           variant="default"
           className="w-full"

--- a/src/pages/ProcessSmsMessages1.tsx
+++ b/src/pages/ProcessSmsMessages1.tsx
@@ -231,7 +231,7 @@ const ProcessSmsMessages = () => {
       <div className="container mx-auto py-[var(--page-padding-y)]">
         <Card>
           <CardHeader>
-            <CardTitle>Process SMS Messages</CardTitle>
+          <CardTitle>Import SMS Messages</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">


### PR DESCRIPTION
## Summary
- add top intro text for SMS import screen
- rename "Process SMS" navigation labels to "Import SMS"

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685839a2237c8333a037c820bc2f1ddf