### PR TITLE
Fix vendor fallback loading

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -123,7 +123,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
   const [newPerson, setNewPerson] = useState<{ name: string; relation: string }>({ name: '', relation: '' });
 
   const [vendors, setVendors] = useState<string[]>(() => {
-    const builtIn = Object.keys((vendorData as any) || {});
+    const builtIn = Object.keys((vendorData as any) || {}).filter(v => v.trim());
     const stored = Object.keys(loadVendorFallbacks());
     return Array.from(new Set([...builtIn, ...stored]));
   });

--- a/src/components/forms/VendorSelector.tsx
+++ b/src/components/forms/VendorSelector.tsx
@@ -25,7 +25,7 @@ const VendorSelector: React.FC<VendorSelectorProps> = ({ form }) => {
   });
 
   useEffect(() => {
-    const builtIn = Object.keys((vendorData as any) || {});
+    const builtIn = Object.keys((vendorData as any) || {}).filter(v => v.trim());
     const stored = Object.keys(loadVendorFallbacks());
     const all = Array.from(new Set([...builtIn, ...stored]));
     setVendors(all);

--- a/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
+++ b/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
@@ -218,7 +218,12 @@ export function initializeXpensiaStorageDefaults() {
 
   // Ensure vendor fallback data exists
   if (!localStorage.getItem('xpensia_vendor_fallbacks')) {
-    saveVendorFallbacks((vendorFallbackData as any).default ?? vendorFallbackData);
+    const initial: Record<string, VendorFallbackData> =
+      (vendorFallbackData as any).default ?? vendorFallbackData;
+    const filtered = Object.fromEntries(
+      Object.entries(initial).filter(([name]) => name.trim())
+    );
+    saveVendorFallbacks(filtered);
     console.log('[Init] xpensia_vendor_fallbacks initialized');
   }
 


### PR DESCRIPTION
## Summary
- filter invalid vendors when initializing fallbacks
- ignore blank vendor entries when building vendor lists

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68583dec72d8833384c4c9b43f19c4de