### PR TITLE
Sanitize vendor fallback keys

### DIFF
--- a/src/lib/smart-paste-engine/__tests__/vendorFallbackUtils.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/vendorFallbackUtils.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from 'bun:test';
+import { loadVendorFallbacks, VENDOR_FALLBACK_KEY } from '../vendorFallbackUtils';
+
+// Simple in-memory localStorage mock
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return store[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+globalThis.localStorage = localStorageMock as any;
+
+test('loadVendorFallbacks strips blank keys and persists result', () => {
+  localStorage.clear();
+  const raw = JSON.stringify({
+    '': { type: 'expense', category: 'Bills', subcategory: 'Utilities' },
+    Netflix: { type: 'expense', category: 'Entertainment', subcategory: 'Streaming' },
+  });
+  localStorage.setItem(VENDOR_FALLBACK_KEY, raw);
+
+  const loaded = loadVendorFallbacks();
+  expect(Object.keys(loaded)).toEqual(['Netflix']);
+
+  const stored = JSON.parse(localStorage.getItem(VENDOR_FALLBACK_KEY) || '{}');
+  expect(Object.keys(stored)).toEqual(['Netflix']);
+});

--- a/src/lib/smart-paste-engine/vendorFallbackUtils.ts
+++ b/src/lib/smart-paste-engine/vendorFallbackUtils.ts
@@ -12,7 +12,19 @@ export function loadVendorFallbacks(): Record<string, VendorFallbackData> {
   const raw = localStorage.getItem(KEY);
   if (!raw) return {};
   try {
-    return JSON.parse(raw) as Record<string, VendorFallbackData>;
+    const parsed = JSON.parse(raw) as Record<string, VendorFallbackData>;
+    const entries = Object.entries(parsed).filter(([k]) => k.trim());
+    const sanitized = Object.fromEntries(entries) as Record<string, VendorFallbackData>;
+
+    if (entries.length !== Object.entries(parsed).length) {
+      try {
+        saveVendorFallbacks(sanitized);
+      } catch {
+        // ignore persistence errors
+      }
+    }
+
+    return sanitized;
   } catch (e) {
     console.error('[VendorFallbackUtils] Failed to parse stored vendor data:', e);
     return {};


### PR DESCRIPTION
## Summary
- sanitize vendor fallback data when loading from localStorage
- add tests to verify blank keys are stripped and persisted

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_685843f2726083339b974c9a05d526df