### PR TITLE
Fix category hierarchy init comment

### DIFF
--- a/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
+++ b/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
@@ -277,10 +277,10 @@ export function initializeXpensiaStorageDefaults() {
   }
   
 
-   // Ensure type keyword bank exists
-if (!localStorage.getItem('xpensia_category_hierarchy')) {
-  localStorage.setItem('xpensia_category_hierarchy', JSON.stringify(CATEGORY_HIERARCHY));
-}
+   // Ensure category hierarchy exists
+   if (!localStorage.getItem('xpensia_category_hierarchy')) {
+     localStorage.setItem('xpensia_category_hierarchy', JSON.stringify(CATEGORY_HIERARCHY));
+   }
   
   
 }


### PR DESCRIPTION
## Summary
- fix comment around `xpensia_category_hierarchy` initialization

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: ENETUNREACH for github.com while installing onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_68584635ef648333b6256c583c38184b