### PR TITLE
Add fs-based vendor fallbacks

### DIFF
--- a/src/lib/smart-paste-engine/__tests__/vendorFallbackUtils.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/vendorFallbackUtils.test.ts
@@ -21,6 +21,7 @@ const localStorageMock = (() => {
 })();
 
 globalThis.localStorage = localStorageMock as any;
+globalThis.window = {} as any;
 
 test('loadVendorFallbacks strips blank keys and persists result', () => {
   localStorage.clear();

--- a/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
+++ b/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
@@ -1,10 +1,7 @@
 import { TransactionType } from '@/types/transaction';
-import vendorFallbackData from '../../data/ksa_all_vendors_clean_final.json';
 import { saveVendorFallbacks, loadVendorFallbacks } from './vendorFallbackUtils';
 
-
-
-	  export const CATEGORY_HIERARCHY = [
+export const CATEGORY_HIERARCHY = [
   {
     id: 'bills', name: 'Bills', type: 'expense' as TransactionType,
     subcategories: [
@@ -216,18 +213,8 @@ export function initializeXpensiaStorageDefaults() {
     console.log('[Init] xpensia_vendor_map initialized');
   }
 
-  // Ensure vendor fallback data exists
-  if (!localStorage.getItem('xpensia_vendor_fallbacks')) {
-    const initial: Record<string, VendorFallbackData> =
-      (vendorFallbackData as any).default ?? vendorFallbackData;
-    const filtered = Object.fromEntries(
-      Object.entries(initial).filter(([name]) => name.trim())
-    );
-    saveVendorFallbacks(filtered);
-    console.log('[Init] xpensia_vendor_fallbacks initialized');
-  } else {
-    // Migration: clean up vendor fallbacks with empty names
-    // Loading and saving ensures blank keys are stripped from storage
+  // Sanitize existing vendor fallback data if present
+  if (localStorage.getItem('xpensia_vendor_fallbacks')) {
     const sanitized = loadVendorFallbacks();
     saveVendorFallbacks(sanitized);
   }

--- a/src/lib/smart-paste-engine/vendorFallbackUtils.ts
+++ b/src/lib/smart-paste-engine/vendorFallbackUtils.ts
@@ -8,7 +8,45 @@ export interface VendorFallbackData {
 
 const KEY = 'xpensia_vendor_fallbacks';
 
+function canUseFs(): boolean {
+  return (
+    typeof window === 'undefined' &&
+    typeof process !== 'undefined' &&
+    !!process.versions?.node
+  );
+}
+
+function getVendorFilePath() {
+  const req = eval('require');
+  const { fileURLToPath } = req('url');
+  const path = req('path');
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, '../../data/ksa_all_vendors_clean_final.json');
+}
+
 export function loadVendorFallbacks(): Record<string, VendorFallbackData> {
+  if (canUseFs()) {
+    try {
+      const req = eval('require');
+      const fs = req('fs') as typeof import('fs');
+      const raw = fs.readFileSync(getVendorFilePath(), 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, VendorFallbackData>;
+      const entries = Object.entries(parsed).filter(([k]) => k.trim());
+      const sanitized = Object.fromEntries(entries) as Record<string, VendorFallbackData>;
+      if (entries.length !== Object.entries(parsed).length) {
+        try {
+          saveVendorFallbacks(sanitized);
+        } catch {
+          // ignore
+        }
+      }
+      return sanitized;
+    } catch (e) {
+      console.error('[VendorFallbackUtils] Failed to load vendor file:', e);
+      return {};
+    }
+  }
+
   const raw = localStorage.getItem(KEY);
   if (!raw) return {};
   try {
@@ -32,6 +70,17 @@ export function loadVendorFallbacks(): Record<string, VendorFallbackData> {
 }
 
 export function saveVendorFallbacks(data: Record<string, VendorFallbackData>): void {
+  if (canUseFs()) {
+    try {
+      const req = eval('require');
+      const fs = req('fs') as typeof import('fs');
+      fs.writeFileSync(getVendorFilePath(), JSON.stringify(data, null, 2), 'utf-8');
+      return;
+    } catch (e) {
+      console.error('[VendorFallbackUtils] Failed to save vendor file:', e);
+    }
+  }
+
   localStorage.setItem(KEY, JSON.stringify(data));
 }
 


### PR DESCRIPTION
## Summary
- load vendor fallbacks from filesystem when running under Node
- persist vendor fallbacks to JSON file when fs is available
- avoid seeding vendor fallback data into localStorage
- adjust vendor fallback test for browser env detection

## Testing
- `bun test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685868ca1e34833390d306ebd99bbb91