### PR TITLE
Improve vendor matching and tests

### DIFF
--- a/src/data/ksa_all_vendors_clean_final.json
+++ b/src/data/ksa_all_vendors_clean_final.json
@@ -1892,117 +1892,117 @@
   "barns": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "dr.": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "starbucks": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "costa": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "%": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "cafe": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "dunkin'": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "tim": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "half": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "brew92": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "elixir": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "wacafe": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "java": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "cova": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "molly's": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "address": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "toby's": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "camel": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "chorisia": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "capital": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "agave": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "brunch": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "good": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "catrion": {
     "type": "Expense",
@@ -2104,7 +2104,7 @@
     "category": "Food",
     "subcategory": "Dining"
   },
-  "brioch\u00e9": {
+  "brioché": {
     "type": "Expense",
     "category": "Food",
     "subcategory": "Dining"
@@ -2279,7 +2279,7 @@
     "category": "Food",
     "subcategory": "Dining Out"
   },
-  "len\u00f4tre": {
+  "lenôtre": {
     "type": "Expense",
     "category": "Food",
     "subcategory": "Dining Out"
@@ -2609,7 +2609,7 @@
     "category": "Food",
     "subcategory": "Sweet"
   },
-  "sucr\u00e9": {
+  "sucré": {
     "type": "Expense",
     "category": "Food",
     "subcategory": "Sweet"
@@ -2979,17 +2979,7 @@
     "category": "Gifts & Donations",
     "subcategory": "Tips"
   },
-  "mada": {
-    "type": "Expense",
-    "category": "Gifts & Donations",
-    "subcategory": "Tips"
-  },
   "halalah": {
-    "type": "Expense",
-    "category": "Gifts & Donations",
-    "subcategory": "Tips"
-  },
-  "cash": {
     "type": "Expense",
     "category": "Gifts & Donations",
     "subcategory": "Tips"
@@ -5517,22 +5507,22 @@
   "thecapitallounge": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "chorisialounge": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "cafebateel": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "urthcaffe": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "obayalounge": {
     "type": "Expense",
@@ -6172,52 +6162,52 @@
   "simitcafe": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "baskinrobbins": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "cinnabon": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "coffeechill": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "barnscafe": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "mado": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "golavita": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "elixirbunn": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "barnespresso": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "cupandcino": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "pizzahut": {
     "type": "Expense",
@@ -6497,22 +6487,22 @@
   "elixirbunncoffee": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "mochaandmore": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "bunzcoffee": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "cofix": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "najdivillage": {
     "type": "Expense",
@@ -7622,17 +7612,17 @@
   "cinnabonegypt": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "costacoffee": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "timhortons": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "alromansiah": {
     "type": "Expense",
@@ -7862,7 +7852,7 @@
   "drcafe": {
     "type": "Expense",
     "category": "Food",
-    "subcategory": "Caf\u00e9"
+    "subcategory": "Café"
   },
   "bernorth": {
     "type": "Expense",

--- a/src/lib/smart-paste-engine/__tests__/suggestionEngine.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/suggestionEngine.test.ts
@@ -1,0 +1,37 @@
+import { mock, test, expect } from 'bun:test';
+
+// Mock string-similarity to avoid dependency installation
+mock.module('string-similarity', () => ({
+  default: { findBestMatch: () => ({ bestMatch: { rating: 0 } }) },
+}));
+
+const { findClosestFallbackMatch } = await import('../suggestionEngine');
+
+// Simple in-memory localStorage mock
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return store[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+globalThis.localStorage = localStorageMock as any;
+
+test('generic vendors mada and cash do not match fallback data', () => {
+  const mada = findClosestFallbackMatch('mada card purchase');
+  expect(mada).toBeNull();
+
+  const cash = findClosestFallbackMatch('cash withdrawal');
+  expect(cash).toBeNull();
+});

--- a/src/lib/smart-paste-engine/suggestionEngine.ts
+++ b/src/lib/smart-paste-engine/suggestionEngine.ts
@@ -32,6 +32,10 @@ const getFallbackVendors = (): Record<string, VendorFallbackData> => {
 const normalize = (str: string): string =>
   str.normalize('NFC').replace(/[\s\-_,×]+/g, '').toLowerCase();
 
+// Escape string for use in regex
+const escapeRegex = (str: string): string =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /* export function findClosestFallbackMatch(vendorName: string): FallbackVendorEntry | null {
   const lowerInput = vendorName.toLowerCase();
   const vendorKeys = Object.keys(fallbackVendors);
@@ -85,9 +89,12 @@ export function findClosestFallbackMatch(vendorName: string): FallbackVendorEntr
     return { vendor: originalKey, ...data };
   }
 
-  // Step 2: Try substring match
+  // Step 2: Try substring match with word boundaries
   for (const key of vendorKeys) {
-    if (lowerInput.includes(softNormalize(key))) {
+    const normalizedKey = softNormalize(key);
+    if (normalizedKey.length < 4) continue; // skip very short keys
+    const pattern = new RegExp(`\\b${escapeRegex(normalizedKey)}\\b`);
+    if (pattern.test(lowerInput)) {
       const data = fallbackVendors[key];
       console.info('[SmartPaste] Substring matched vendor:', key, '→', data);
       return { vendor: key, ...data };


### PR DESCRIPTION
## Summary
- refine substring matching logic to ignore short names and require word boundaries
- remove `mada` and `cash` entries from vendor dataset
- add regression test to ensure generic vendor words don't match

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68586a7019248333ac59f59463b2cf63