### PR TITLE
Prevent crash with missing vendor fallback data

### DIFF
--- a/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
+++ b/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
@@ -1,5 +1,10 @@
 import { TransactionType } from '@/types/transaction';
-import { saveVendorFallbacks, loadVendorFallbacks } from './vendorFallbackUtils';
+import vendorFallbackData from '../../data/ksa_all_vendors_clean_final.json';
+import {
+  saveVendorFallbacks,
+  loadVendorFallbacks,
+  VendorFallbackData,
+} from './vendorFallbackUtils';
 
 export const CATEGORY_HIERARCHY = [
   {
@@ -213,8 +218,17 @@ export function initializeXpensiaStorageDefaults() {
     console.log('[Init] xpensia_vendor_map initialized');
   }
 
-  // Sanitize existing vendor fallback data if present
-  if (localStorage.getItem('xpensia_vendor_fallbacks')) {
+  // Ensure vendor fallback data exists
+  if (!localStorage.getItem('xpensia_vendor_fallbacks')) {
+    const initial: Record<string, VendorFallbackData> =
+      (vendorFallbackData as any).default ?? vendorFallbackData;
+    const filtered = Object.fromEntries(
+      Object.entries(initial).filter(([name]) => name.trim())
+    );
+    saveVendorFallbacks(filtered);
+    console.log('[Init] xpensia_vendor_fallbacks initialized');
+  } else {
+    // Sanitize existing vendor fallback data if present
     const sanitized = loadVendorFallbacks();
     saveVendorFallbacks(sanitized);
   }

--- a/src/lib/smart-paste-engine/suggestionEngine.ts
+++ b/src/lib/smart-paste-engine/suggestionEngine.ts
@@ -30,7 +30,15 @@ export function findClosestFallbackMatch(vendorName: string): FallbackVendorEntr
   console.log('[SmartPaste] Starting fallback match for vendor:', vendorName);
   const lowerInput = softNormalize(vendorName);
   const fallbackVendors = getFallbackVendors();
+  if (!fallbackVendors || typeof fallbackVendors !== 'object') {
+    console.warn('[SmartPaste] Invalid fallback vendor structure:', fallbackVendors);
+    return null;
+  }
   const vendorKeys = Object.keys(fallbackVendors);
+  if (vendorKeys.length === 0) {
+    console.warn('[SmartPaste] No fallback vendors available');
+    return null;
+  }
 
   const match = stringSimilarity.findBestMatch(lowerInput, vendorKeys.map(softNormalize));
   const originalKeysMap = Object.fromEntries(vendorKeys.map(key => [softNormalize(key), key]));

--- a/src/lib/smart-paste-engine/vendorFallbackUtils.ts
+++ b/src/lib/smart-paste-engine/vendorFallbackUtils.ts
@@ -8,45 +8,7 @@ export interface VendorFallbackData {
 
 const KEY = 'xpensia_vendor_fallbacks';
 
-function canUseFs(): boolean {
-  return (
-    typeof window === 'undefined' &&
-    typeof process !== 'undefined' &&
-    !!process.versions?.node
-  );
-}
-
-function getVendorFilePath() {
-  const req = eval('require');
-  const { fileURLToPath } = req('url');
-  const path = req('path');
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  return path.resolve(__dirname, '../../data/ksa_all_vendors_clean_final.json');
-}
-
 export function loadVendorFallbacks(): Record<string, VendorFallbackData> {
-  if (canUseFs()) {
-    try {
-      const req = eval('require');
-      const fs = req('fs') as typeof import('fs');
-      const raw = fs.readFileSync(getVendorFilePath(), 'utf-8');
-      const parsed = JSON.parse(raw) as Record<string, VendorFallbackData>;
-      const entries = Object.entries(parsed).filter(([k]) => k.trim());
-      const sanitized = Object.fromEntries(entries) as Record<string, VendorFallbackData>;
-      if (entries.length !== Object.entries(parsed).length) {
-        try {
-          saveVendorFallbacks(sanitized);
-        } catch {
-          // ignore
-        }
-      }
-      return sanitized;
-    } catch (e) {
-      console.error('[VendorFallbackUtils] Failed to load vendor file:', e);
-      return {};
-    }
-  }
-
   const raw = localStorage.getItem(KEY);
   if (!raw) return {};
   try {
@@ -70,17 +32,6 @@ export function loadVendorFallbacks(): Record<string, VendorFallbackData> {
 }
 
 export function saveVendorFallbacks(data: Record<string, VendorFallbackData>): void {
-  if (canUseFs()) {
-    try {
-      const req = eval('require');
-      const fs = req('fs') as typeof import('fs');
-      fs.writeFileSync(getVendorFilePath(), JSON.stringify(data, null, 2), 'utf-8');
-      return;
-    } catch (e) {
-      console.error('[VendorFallbackUtils] Failed to save vendor file:', e);
-    }
-  }
-
   localStorage.setItem(KEY, JSON.stringify(data));
 }
 


### PR DESCRIPTION
## Summary
- guard against empty or invalid vendor fallback data in `findClosestFallbackMatch`
- load vendor fallbacks from JSON on first run and persist to local storage

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6859aa559ec48333a7b364cf38553b86