### PR TITLE
Update bottom nav icons

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,12 +1,32 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Home, List, BarChart3, Settings } from 'lucide-react';
+import {
+  Home,
+  ClipboardPaste,
+  MessageSquareText,
+  LineChart
+} from 'lucide-react';
 
 const navItems = [
-  { name: 'Home', path: '/home', icon: Home },
-  { name: 'Transactions', path: '/transactions', icon: List },
-  { name: 'Reports', path: '/analytics', icon: BarChart3 },
-  { name: 'Settings', path: '/settings', icon: Settings }
+  { name: 'Home', path: '/home', icon: Home, color: 'text-blue-600' },
+  {
+    name: 'Paste SMS',
+    path: '/import-transactions',
+    icon: ClipboardPaste,
+    color: 'text-purple-600'
+  },
+  {
+    name: 'Import SMS',
+    path: '/process-sms',
+    icon: MessageSquareText,
+    color: 'text-green-600'
+  },
+  {
+    name: 'Analytics',
+    path: '/analytics',
+    icon: LineChart,
+    color: 'text-orange-600'
+  }
 ];
 
 const BottomNav: React.FC = () => {
@@ -14,14 +34,14 @@ const BottomNav: React.FC = () => {
   return (
     <nav className="md:hidden fixed bottom-0 left-0 right-0 z-30 bg-background border-t border-border">
       <ul className="flex justify-around py-2">
-        {navItems.map(({ name, path, icon: Icon }) => (
+        {navItems.map(({ name, path, icon: Icon, color }) => (
           <li key={path}>
             <Link
               to={path}
               className={`flex flex-col items-center text-xs ${location.pathname === path ? 'text-primary' : 'text-muted-foreground'}`}
               aria-label={name}
             >
-              <Icon size={20} />
+              <Icon className={color} size={20} />
               {name}
             </Link>
           </li>


### PR DESCRIPTION
## Summary
- replace bottom navigation items with Paste SMS / Import SMS / Analytics
- use clipboard, SMS and chart icons with colors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859b40e7b7483339ef8b96a4d917aaa