### PR TITLE
Remove clipboard paste button from SmartPaste

### DIFF
--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -199,14 +199,6 @@ const handleSubmit = (e: React.FormEvent) => {
             {isProcessing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Extract Transaction
           </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handlePaste}
-            disabled={isProcessing}
-          >
-            Paste from Clipboard
-          </Button>
         </div>
 
         {confidence !== null && (


### PR DESCRIPTION
## Summary
- remove the "Paste from Clipboard" button from `SmartPaste.tsx`
- verified `TransactionInput.tsx` is unused so no change needed

## Testing
- `npm install` *(fails: connect ENETUNREACH)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6859b414ff1c8333ac4ed4089c7d60da