### PR TITLE
Defer heavy initialization

### DIFF
--- a/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
+++ b/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
@@ -1,5 +1,4 @@
 import { TransactionType } from '@/types/transaction';
-import vendorFallbackData from '../../data/ksa_all_vendors_clean_final.json';
 import {
   saveVendorFallbacks,
   loadVendorFallbacks,
@@ -205,7 +204,7 @@ export const CATEGORY_HIERARCHY = [
   
 
 
-export function initializeXpensiaStorageDefaults() {
+export async function initializeXpensiaStorageDefaults(): Promise<void> {
   // Ensure structure templates store exists
   if (!localStorage.getItem('xpensia_structure_templates')) {
     localStorage.setItem('xpensia_structure_templates', JSON.stringify([]));
@@ -220,8 +219,9 @@ export function initializeXpensiaStorageDefaults() {
 
   // Ensure vendor fallback data exists
   if (!localStorage.getItem('xpensia_vendor_fallbacks')) {
+    const module = await import('../../data/ksa_all_vendors_clean_final.json');
     const initial: Record<string, VendorFallbackData> =
-      (vendorFallbackData as any).default ?? vendorFallbackData;
+      (module as any).default ?? module;
     const filtered = Object.fromEntries(
       Object.entries(initial).filter(([name]) => name.trim())
     );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,8 +16,18 @@ try {
   console.error('[Capacitor] Initialization error:', err);
 }
 
-initializeXpensiaStorageDefaults();
-demoTransactionService.seedDemoTransactions();
+const defer = (fn: () => void) => {
+  if ('requestIdleCallback' in window) {
+    (window as any).requestIdleCallback(fn);
+  } else {
+    setTimeout(fn, 0);
+  }
+};
+
+defer(() => {
+  initializeXpensiaStorageDefaults();
+  demoTransactionService.seedDemoTransactions();
+});
 
 
 // Setup global error handlers


### PR DESCRIPTION
## Summary
- lazily load vendor fallback data only when needed
- defer heavy initialization steps to `requestIdleCallback` when possible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b01d0604c8333aa350d93c4dc597e