### PR TITLE
Defer initialization further

### DIFF
--- a/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
+++ b/src/lib/smart-paste-engine/initializeXpensiaStorageDefaults.ts
@@ -1,5 +1,4 @@
 import { TransactionType } from '@/types/transaction';
-import vendorFallbackData from '../../data/ksa_all_vendors_clean_final.json';
 import {
   saveVendorFallbacks,
   loadVendorFallbacks,
@@ -205,7 +204,7 @@ export const CATEGORY_HIERARCHY = [
   
 
 
-export function initializeXpensiaStorageDefaults() {
+export async function initializeXpensiaStorageDefaults(): Promise<void> {
   // Ensure structure templates store exists
   if (!localStorage.getItem('xpensia_structure_templates')) {
     localStorage.setItem('xpensia_structure_templates', JSON.stringify([]));
@@ -220,8 +219,9 @@ export function initializeXpensiaStorageDefaults() {
 
   // Ensure vendor fallback data exists
   if (!localStorage.getItem('xpensia_vendor_fallbacks')) {
+    const module = await import('../../data/ksa_all_vendors_clean_final.json');
     const initial: Record<string, VendorFallbackData> =
-      (vendorFallbackData as any).default ?? vendorFallbackData;
+      (module as any).default ?? module;
     const filtered = Object.fromEntries(
       Object.entries(initial).filter(([name]) => name.trim())
     );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,8 +16,18 @@ try {
   console.error('[Capacitor] Initialization error:', err);
 }
 
-initializeXpensiaStorageDefaults();
-demoTransactionService.seedDemoTransactions();
+const defer = (fn: () => void | Promise<void>) => {
+  if ('requestIdleCallback' in window) {
+    (window as any).requestIdleCallback(fn);
+  } else {
+    setTimeout(fn, 0);
+  }
+};
+
+defer(async () => {
+  await initializeXpensiaStorageDefaults();
+  demoTransactionService.seedDemoTransactions();
+});
 
 
 // Setup global error handlers

--- a/src/services/DemoTransactionService.ts
+++ b/src/services/DemoTransactionService.ts
@@ -1,6 +1,7 @@
 import { Transaction, TransactionType } from '@/types/transaction';
 import { v4 as uuidv4 } from 'uuid';
 import { getCategoryHierarchy, CURRENCIES } from '@/lib/categories-data';
+import { ENABLE_DEMO_MODE } from '@/lib/env';
 import { transactionStore } from '@/state/transactionStore';
 
 const FROM_ACCOUNTS = [
@@ -30,6 +31,9 @@ const INIT_FLAG_KEY = 'xpensia_demo_transactions_initialized';
 
 class DemoTransactionService {
   seedDemoTransactions(): void {
+    if (!ENABLE_DEMO_MODE) {
+      return;
+    }
     if (localStorage.getItem(INIT_FLAG_KEY)) {
       return;
     }
@@ -65,7 +69,7 @@ class DemoTransactionService {
     categories.forEach(cat => {
       const subs = cat.subcategories.length > 0 ? cat.subcategories.map(s => s.name) : [cat.name];
       subs.forEach(sub => {
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < 2; i++) {
           newTransactions.push({
             id: uuidv4(),
             title: sub,


### PR DESCRIPTION
## Summary
- wait for vendor data load before seeding demo transactions
- skip seeding when demo mode is disabled
- reduce demo transactions to 2 per subcategory

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b01d0604c8333aa350d93c4dc597e