### PR TITLE
Update navigation and remove paste button

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Home, List, BarChart3, Settings } from 'lucide-react';
+import { Home, Upload, MessageSquare, LineChart } from 'lucide-react';
 
 const navItems = [
-  { name: 'Home', path: '/home', icon: Home },
-  { name: 'Transactions', path: '/transactions', icon: List },
-  { name: 'Reports', path: '/analytics', icon: BarChart3 },
-  { name: 'Settings', path: '/settings', icon: Settings }
+  { name: 'Home', path: '/home', icon: Home, color: 'text-blue-500' },
+  { name: 'Paste SMS', path: '/import-transactions', icon: Upload, color: 'text-green-500' },
+  { name: 'Import SMS', path: '/process-sms', icon: MessageSquare, color: 'text-orange-500' },
+  { name: 'Analytics', path: '/analytics', icon: LineChart, color: 'text-purple-500' }
 ];
 
 const BottomNav: React.FC = () => {
@@ -14,14 +14,14 @@ const BottomNav: React.FC = () => {
   return (
     <nav className="md:hidden fixed bottom-0 left-0 right-0 z-30 bg-background border-t border-border">
       <ul className="flex justify-around py-2">
-        {navItems.map(({ name, path, icon: Icon }) => (
+        {navItems.map(({ name, path, icon: Icon, color }) => (
           <li key={path}>
             <Link
               to={path}
-              className={`flex flex-col items-center text-xs ${location.pathname === path ? 'text-primary' : 'text-muted-foreground'}`}
-              aria-label={name}
-            >
-              <Icon size={20} />
+              className={`flex flex-col items-center text-xs ${location.pathname === path ? color : 'text-muted-foreground'}`}
+            aria-label={name}
+          >
+              <Icon size={20} className={location.pathname === path ? color : ''} />
               {name}
             </Link>
           </li>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -161,7 +161,7 @@ const Header = ({ className, showNavigation = true }: HeaderProps) => {
                 <Sheet>
                   <SheetTrigger asChild>
                     <Button variant="ghost" size="icon" aria-label="Open navigation menu">
-                      <Menu size={20} />
+                      <Menu size={24} />
                     </Button>
                   </SheetTrigger>
                   <SheetContent side="left" className="w-[300px] sm:w-[400px]">

--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -194,18 +194,9 @@ const handleSubmit = (e: React.FormEvent) => {
         </div>
 
         <div className="flex flex-col sm:flex-row sm:justify-start gap-2">
-          <Button type="submit" disabled={isProcessing || !text.trim()}
-            >
+          <Button type="submit" disabled={isProcessing || !text.trim()}>
             {isProcessing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Extract Transaction
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handlePaste}
-            disabled={isProcessing}
-          >
-            Paste from Clipboard
           </Button>
         </div>
 

--- a/src/components/header/MobileNavigation.tsx
+++ b/src/components/header/MobileNavigation.tsx
@@ -41,7 +41,7 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({ currentPageT
       <Sheet>
         <SheetTrigger asChild>
           <Button variant="ghost" size="icon" aria-label="Open navigation menu">
-            <Menu size={20} />
+            <Menu size={24} />
           </Button>
         </SheetTrigger>
         <SheetContent side="left" className="w-[300px] sm:w-[400px]">


### PR DESCRIPTION
## Summary
- expand the hamburger icon size
- change bottom nav to show paste and import actions with colored icons
- clean up SmartPaste form by removing clipboard button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685bf0e9ea84833392c2bf8993e4d8e7