### PR TITLE
Fix category chart legend layout

### DIFF
--- a/src/components/charts/CategoryChart.tsx
+++ b/src/components/charts/CategoryChart.tsx
@@ -90,7 +90,20 @@ const CategoryChart: React.FC<CategoryChartProps> = ({ data }) => {
                     {formatCurrency(total)}
                   </text>
                   <Tooltip formatter={(value) => formatCurrency(Math.abs(Number(value)))} />
-                  <Legend layout="horizontal" align="center" verticalAlign="bottom" />
+                  <Legend
+                    layout="horizontal"
+                    align="center"
+                    verticalAlign="bottom"
+                    wrapperStyle={{
+                      fontSize: '12px',
+                      paddingTop: '10px',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      width: '100%',
+                      whiteSpace: 'nowrap',
+                      overflowX: 'auto',
+                    }}
+                  />
                 </PieChart>
               </ResponsiveContainer>
             </div>


### PR DESCRIPTION
## Summary
- ensure the legend in the category chart stays on a single line

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c3ff93f2883338a6c6693e27887a2