### PR TITLE
Improve SMS reader limit

### DIFF
--- a/src/services/SmsReaderService.ts
+++ b/src/services/SmsReaderService.ts
@@ -67,6 +67,9 @@ export class SmsReaderService {
     }
 
     const monthsBack = parseInt(localStorage.getItem('xpensia_sms_period_months') || '6');
+    // Fetch limit to pass to the native plugin. Allows overriding via localStorage.
+    // Defaults to 500 messages which is higher than the plugin's default of 100.
+    const limit = parseInt(localStorage.getItem('xpensia_sms_fetch_limit') || '500');
     const startDate = subMonths(startOfToday(), monthsBack).getTime();
     const endDate = Date.now();
     console.log(`[SmsReaderService] Filtering from ${new Date(startDate).toISOString()} to ${new Date(endDate).toISOString()}`);
@@ -77,6 +80,7 @@ export class SmsReaderService {
         ...options,
         startDate: String(startDate),
         endDate: String(endDate),
+        limit,
       });
       
       if (!result || !Array.isArray(result.messages)) {


### PR DESCRIPTION
## Summary
- allow `SmsReaderService` to fetch up to 500 messages or value from local storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: connect ENETUNREACH to github.com)*

------
https://chatgpt.com/codex/tasks/task_e_685c45e0d2b48333b9b17884a4b2e125