### PR TITLE
Update Review SMS page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import ProcessSmsMessages from '@/pages/ProcessSmsMessages';
 import ProcessVendors from '@/pages/sms/ProcessVendors';
 import VendorCategorization from '@/pages/sms/VendorCategorization';
 import VendorMapping from '@/pages/VendorMapping';
-import ReviewDraftTransactions from '@/pages/ReviewDraftTransactions';
+import ReviewSmsTransactions from '@/pages/ReviewSmsTransactions';
 import Analytics from './pages/Analytics';
 import Settings from './pages/Settings';
 import NotFound from './pages/NotFound';
@@ -184,7 +184,7 @@ function AppWrapper() {
       <Route path="/sms/process-vendors" element={<ProcessVendors />} />
       <Route path="/sms/vendors" element={<VendorCategorization />} />
       <Route path="/vendor-mapping" element={<VendorMapping />} />
-      <Route path="/review-draft-transactions" element={<ReviewDraftTransactions />} />
+      <Route path="/review-sms-transactions" element={<ReviewSmsTransactions />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -18,6 +18,7 @@ export const routeTitleMap: Record<string, string> = {
   '/wireframes/sms-provider': 'SMS Provider',
   '/wireframes/sms-transaction': 'SMS Transaction',
   '/import-transactions': 'Paste & Parse',
+  '/review-sms-transactions': 'Review SMS Transactions',
   '/edit-transaction': 'Transaction',
 };
 

--- a/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
+++ b/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
@@ -13,6 +13,7 @@ interface SaveOptions {
   updateTransaction: (txn: Transaction) => void;
   learnFromTransaction: (msg: string, txn: Transaction, hint: string) => void;
   navigateBack: () => void;
+  silent?: boolean;
 }
 
 export function saveTransactionWithLearning(
@@ -27,6 +28,7 @@ export function saveTransactionWithLearning(
     updateTransaction,
     learnFromTransaction,
     navigateBack,
+    silent = false,
   } = options;
 
   const newTransaction: Transaction = {
@@ -56,10 +58,12 @@ export function saveTransactionWithLearning(
       saveNewTemplate(template, fields, rawMessage);
     }
 
-    toast({
-      title: 'Pattern saved for learning',
-      description: 'Future similar messages will be recognized automatically',
-    });
+    if (!silent) {
+      toast({
+        title: 'Pattern saved for learning',
+        description: 'Future similar messages will be recognized automatically',
+      });
+    }
 
     // Keyword Bank Mapping
     const keyword = placeholders?.vendor?.toLowerCase() || newTransaction.vendor.toLowerCase();
@@ -107,10 +111,12 @@ export function saveTransactionWithLearning(
     }
   }
 
-  toast({
-    title: isNew ? 'Transaction created' : 'Transaction updated',
-    description: `Your transaction has been successfully ${isNew ? 'created' : 'updated'}`,
-  });
+  if (!silent) {
+    toast({
+      title: isNew ? 'Transaction created' : 'Transaction updated',
+      description: `Your transaction has been successfully ${isNew ? 'created' : 'updated'}`,
+    });
+  }
 
   navigateBack();
 }

--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -7,9 +7,8 @@ import { extractTemplateStructure } from '@/lib/smart-paste-engine/templateUtils
 import { parseAndInferTransaction } from '@/lib/smart-paste-engine/parseAndInferTransaction';
 import { saveTransactionWithLearning } from '@/lib/smart-paste-engine/saveTransactionWithLearning';
 import { generateDefaultTitle } from '@/components/TransactionEditForm';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import Layout from '@/components/Layout';
-import { ArrowLeft } from 'lucide-react';
 import { getCategoriesForType, getSubcategoriesForCategory} from '@/lib/categories-data';
 import { useTransactions } from '@/context/TransactionContext';
 
@@ -27,11 +26,10 @@ interface DraftTransaction {
   rawMessage: string;
 }
 
-const ReviewDraftTransactions: React.FC = () => {
+const ReviewSmsTransactions: React.FC = () => {
   const [transactions, setTransactions] = useState<DraftTransaction[]>([]);
   const { toast } = useToast();
   const location = useLocation();
-  const navigate = useNavigate();
   const { addTransaction, updateTransaction } = useTransactions();
 
   const messages: any[] = location.state?.messages || [];
@@ -146,6 +144,7 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
         updateTransaction,
         learnFromTransaction: () => {},
         navigateBack: () => {},
+        silent: true,
       });
     });
 
@@ -158,14 +157,9 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
   };
 
   return (
-    <Layout>
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
-          <Button variant="outline" size="icon" onClick={() => navigate(-1)}>
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <h1 className="text-xl sm:text-2xl font-bold">Review SMS Transactions</h1>
-        </div>
+    <Layout showBack>
+      <div className="flex justify-end mb-4">
+        <Button onClick={handleSave}>Save All</Button>
       </div>
 
       {transactions.map((txn, index) => (
@@ -208,4 +202,4 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
   );
 };
 
-export default ReviewDraftTransactions;
+export default ReviewSmsTransactions;

--- a/src/pages/VendorMapping.tsx
+++ b/src/pages/VendorMapping.tsx
@@ -111,7 +111,7 @@ const handleConfirm = () => {
 
     const messages = location.state?.messages || [];
 
-    navigate('/review-draft-transactions', {
+    navigate('/review-sms-transactions', {
       state: {
         messages,
         vendorMap,


### PR DESCRIPTION
## Summary
- rename page to `ReviewSmsTransactions`
- show `Save All` button at top of the page
- enable header title via route constants
- suppress toast spam during bulk save
- update navigation links to new route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c5457fd748333bf30a9f67f4d3b17