### PR TITLE
Handle localStorage quota errors

### DIFF
--- a/src/context/user/UserContext.tsx
+++ b/src/context/user/UserContext.tsx
@@ -22,6 +22,7 @@ import {
   checkUserExists as checkUserExistsUtil,
   isProfileComplete as isProfileCompleteUtil
 } from './auth-utils';
+import { safeSetItem } from '@/utils/storage-utils';
 import {
   updateUserPreferences as updateUserPreferencesUtil,
   updateDisplayOptions as updateDisplayOptionsUtil,
@@ -139,7 +140,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // Save user to local storage whenever it changes
   useEffect(() => {
     if (user) {
-      localStorage.setItem('user', JSON.stringify(user));
+      safeSetItem('user', user);
       
       // If Supabase is enabled, also update the user profile there
       if (ENABLE_SUPABASE_AUTH && isSupabaseConfigured() && user.id) {

--- a/src/context/user/auth-utils.ts
+++ b/src/context/user/auth-utils.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/supabase-auth';
 import { ErrorType } from '@/types/error';
 import { createError } from '@/utils/error-utils';
+import { safeSetItem } from '@/utils/storage-utils';
 
 /**
  * Check if a user with the given phone number exists
@@ -155,7 +156,7 @@ export const checkSupabaseAuth = async (
           }));
           
           // Update localStorage
-          localStorage.setItem('user', JSON.stringify(updatedUser));
+          safeSetItem('user', updatedUser);
           return;
         }
       }

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -39,6 +39,33 @@ const setInStorage = <T>(key: string, data: T): void => {
   }
 };
 
+/**
+ * Attempts to persist a value in localStorage.
+ * Returns true on success and false if an error occurred
+ * (e.g. QuotaExceededError).
+ */
+export const safeSetItem = <T>(key: string, data: T): boolean => {
+  try {
+    localStorage.setItem(key, JSON.stringify(data));
+    return true;
+  } catch (error: any) {
+    const isQuotaExceeded =
+      error instanceof DOMException &&
+      (error.name === 'QuotaExceededError' || error.code === 22 || error.code === 1014);
+
+    if (isQuotaExceeded) {
+      console.error(
+        `[CRITICAL] Failed to set '${key}' in localStorage due to quota limitations.`,
+        error
+      );
+    } else {
+      console.error(`Error storing ${key} in storage:`, error);
+    }
+
+    return false;
+  }
+};
+
 // Transactions storage functions
 export const getStoredTransactions = (): Transaction[] => {
   return getFromStorage<Transaction[]>(TRANSACTIONS_STORAGE_KEY, []);


### PR DESCRIPTION
## Summary
- add a `safeSetItem` helper that logs quota errors
- use `safeSetItem` when persisting user state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d94be43d88333bf612e83a13cf816