### PR TITLE
Update card styling for dark mode

### DIFF
--- a/src/components/transactions/TransactionsByDate.tsx
+++ b/src/components/transactions/TransactionsByDate.tsx
@@ -56,7 +56,7 @@ const TransactionsByDate: React.FC<TransactionsByDateProps> = ({
         const netCurrency = groupedTransactions[date][0]?.currency || 'USD';
         return (
           <div key={date} className="space-y-[var(--card-gap)]">
-            <h3 className="font-semibold text-gray-600 text-sm">
+            <h3 className="font-semibold text-card-foreground dark:text-white text-sm">
               {formatDate(date)}
             </h3>
 
@@ -72,7 +72,7 @@ const TransactionsByDate: React.FC<TransactionsByDateProps> = ({
                 return (
                   <div
                     key={transaction.id?.trim() || `txn-${date}-${index}`}
-                    className="bg-white rounded-2xl shadow-sm border border-gray-200 px-4 py-3"
+                    className="bg-card text-card-foreground dark:bg-black dark:text-white rounded-2xl shadow-sm border px-4 py-3"
                   >
                     <div className="flex justify-between items-center">
                       <div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -283,7 +283,7 @@ const Dashboard = () => {
                       key={transaction.id || idx}
                       onClick={() => navigate(`/edit-transaction/${transaction.id}`)}
                       aria-label="Edit transaction"
-                      className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 hover:shadow-md hover:bg-gray-50 transition-all cursor-pointer"
+                      className="bg-card text-card-foreground dark:bg-black dark:text-white rounded-lg shadow-sm border px-4 py-3 hover:shadow-md transition-all cursor-pointer"
                     >
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -294,7 +294,7 @@ const Home = () => {
                         })
                       }
                       aria-label="Edit transaction"
-                      className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 hover:shadow-md hover:bg-gray-50 transition-all cursor-pointer"
+                      className="bg-card text-card-foreground dark:bg-black dark:text-white rounded-lg shadow-sm border px-4 py-3 hover:shadow-md transition-all cursor-pointer"
                     >
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">


### PR DESCRIPTION
## Summary
- switch transaction cards to use `bg-card` and `text-card-foreground`
- add dark mode overrides to recent transaction lists
- update date headers inside grouped transactions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because of network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685de128fc948333ae6d6b0c67465af6