### PR TITLE
Apply dark theme overrides in date picker

### DIFF
--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -59,7 +59,7 @@ export function DatePicker({
         <Button
           variant={"outline"}
           className={cn(
-            "w-full justify-start text-left font-normal",
+            "w-full justify-start text-left font-normal dark:bg-black dark:text-white",
             !date && "text-muted-foreground",
             className
           )}
@@ -68,7 +68,10 @@ export function DatePicker({
           {date ? format(date, "PPP") : <span>{placeholder}</span>}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0 pointer-events-auto" align="start">
+      <PopoverContent
+        className="w-auto p-0 pointer-events-auto dark:bg-black dark:text-white"
+        align="start"
+      >
         <Calendar
           mode="single"
           selected={date || undefined}


### PR DESCRIPTION
## Summary
- ensure the date picker button uses dark background and text
- match the calendar popover content with the same dark overrides

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: ENETUNREACH while downloading onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_685de3d818b88333a60c045c0d4caf9b