### PR TITLE
Fix dark mode card styling

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -376,7 +376,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
   const darkFieldClass =
     'dark:bg-black dark:text-white dark:border-zinc-700 dark:placeholder-gray-400';
   const formClass = cn(
-    'bg-white p-4 rounded-md shadow-sm',
+    'bg-card p-4 rounded-md shadow-sm',
     compact ? 'space-y-1 pb-16' : 'space-y-2 pb-28'
   );
 


### PR DESCRIPTION
## Summary
- adjust transaction form container to use theme card color so dark mode has the correct background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e5a27bbc483339f83a51a9298b2bd