### PR TITLE
Fix dark mode card styling

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -370,13 +370,13 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
   const rowClass = cn('flex items-center', compact ? 'gap-1' : 'gap-2');
   const labelClass = cn(
     compact ? 'w-24 md:w-28' : 'w-32',
-    'text-sm font-semibold text-gray-700 dark:text-white dark:bg-black'
+    'text-sm font-semibold text-gray-700 dark:text-white bg-card'
   );
   const inputPadding = compact ? 'py-1 px-2' : 'py-2 px-3';
   const darkFieldClass =
     'dark:bg-black dark:text-white dark:border-zinc-700 dark:placeholder-gray-400';
   const formClass = cn(
-    'bg-white p-4 rounded-md shadow-sm',
+    'bg-card p-4 rounded-md shadow-sm',
     compact ? 'space-y-1 pb-16' : 'space-y-2 pb-28'
   );
 


### PR DESCRIPTION
## Summary
- adjust transaction form container to use theme card color so dark mode has the correct background
- make form labels use the card color background instead of black

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e5a27bbc483339f83a51a9298b2bd