### PR TITLE
Highlight autofilled fields in dark mode

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -28,10 +28,12 @@ interface TransactionEditFormProps {
   showNotes?: boolean;
 }
 
-function getDrivenFieldStyle(field: keyof Transaction, drivenFields: Partial<Record<keyof Transaction, boolean>>) {
-  return drivenFields[field]
-    ? { border: '2px solid #4caf50', backgroundColor: '#f0fff4' }
-    : {};
+
+function isDriven(
+  field: keyof Transaction,
+  drivenFields: Partial<Record<keyof Transaction, boolean>>
+) {
+  return !!drivenFields[field]
 }
 
 /* export function generateDefaultTitle(txn: Transaction): string {
@@ -397,7 +399,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
               'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
               darkFieldClass
             )}
-            style={getDrivenFieldStyle('type', drivenFields)}
+            isAutoFilled={isDriven('type', drivenFields)}
           >
             <SelectValue placeholder="Select type" />
           </SelectTrigger>
@@ -419,7 +421,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
             setTitleManuallyEdited(true);
             handleChange('title', e.target.value);
           }}
-          style={getDrivenFieldStyle('title', drivenFields)}
+          isAutoFilled={isDriven('title', drivenFields)}
           placeholder="Transaction title"
           required
           className={cn(
@@ -447,7 +449,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
                 'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
                 darkFieldClass
               )}
-              style={getDrivenFieldStyle('currency', drivenFields)}
+              isAutoFilled={isDriven('currency', drivenFields)}
             >
               <SelectValue placeholder="Select currency" />
             </SelectTrigger>
@@ -703,12 +705,12 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
         <label className={labelClass}>Amount*</label>
 
         <div className="flex w-full items-center gap-1">
-          <Input
-            type="number"
-            step="0.01"
-            value={editedTransaction.amount}
-            style={getDrivenFieldStyle('amount', drivenFields)}
-            onChange={(e) => handleChange('amount', parseFloat(e.target.value))}
+            <Input
+              type="number"
+              step="0.01"
+              value={editedTransaction.amount}
+              isAutoFilled={isDriven('amount', drivenFields)}
+              onChange={(e) => handleChange('amount', parseFloat(e.target.value))}
             placeholder="0.00"
             required
           className={cn(
@@ -734,11 +736,11 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
         <label className={labelClass}>From Account*</label>
 
         <div className="flex w-full items-center gap-1">
-          <Input
-            list="accounts-list"
-            value={editedTransaction.fromAccount || ''}
-            onChange={(e) => handleChange('fromAccount', e.target.value)}
-            style={getDrivenFieldStyle('fromAccount', drivenFields)}
+            <Input
+              list="accounts-list"
+              value={editedTransaction.fromAccount || ''}
+              onChange={(e) => handleChange('fromAccount', e.target.value)}
+              isAutoFilled={isDriven('fromAccount', drivenFields)}
             placeholder="Source account"
             required
             className={cn(
@@ -768,7 +770,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
               list="accounts-list"
               value={editedTransaction.toAccount || ''}
               onChange={(e) => handleChange('toAccount', e.target.value)}
-              style={getDrivenFieldStyle('toAccount', drivenFields)}
+              isAutoFilled={isDriven('toAccount', drivenFields)}
               placeholder="Destination account"
               required
               className={cn(
@@ -801,7 +803,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
                 'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
                 darkFieldClass
               )}
-              style={getDrivenFieldStyle('category', drivenFields)}
+              isAutoFilled={isDriven('category', drivenFields)}
             >
               <SelectValue placeholder="Select category" />
             </SelectTrigger>
@@ -842,7 +844,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
                 'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
                 darkFieldClass
               )}
-              style={getDrivenFieldStyle('subcategory', drivenFields)}
+              isAutoFilled={isDriven('subcategory', drivenFields)}
             >
               <SelectValue placeholder="Select subcategory" />
             </SelectTrigger>
@@ -902,7 +904,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
           <Input
             list="vendors-list"
             value={editedTransaction.vendor || ''}
-            style={getDrivenFieldStyle('vendor', drivenFields)}
+            isAutoFilled={isDriven('vendor', drivenFields)}
             onChange={(e) => handleChange('vendor', e.target.value)}
             placeholder="e.g., Netflix"
             className={cn(
@@ -931,7 +933,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
           type="date"
           value={editedTransaction.date || ''}
           onChange={(e) => handleChange('date', e.target.value)}
-          style={getDrivenFieldStyle('date', drivenFields)}
+          isAutoFilled={isDriven('date', drivenFields)}
           required
           className={cn(
             'w-full text-sm',
@@ -954,6 +956,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
           }}
           placeholder="Enter a detailed description..."
           rows={2}
+          isAutoFilled={isDriven('description', drivenFields)}
           className={cn(
             'w-full text-sm',
             inputPadding,
@@ -973,6 +976,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
             onChange={(e) => handleChange('notes', e.target.value)}
             placeholder="Additional notes..."
             rows={2}
+            isAutoFilled={isDriven('notes', drivenFields)}
             className={cn(
               'w-full text-sm',
               inputPadding,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,13 +2,18 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+export interface InputProps extends React.ComponentProps<"input"> {
+  isAutoFilled?: boolean
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, isAutoFilled, ...props }, ref) => {
     return (
       <input
         type={type}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          isAutoFilled && "border-green-400 bg-green-50 dark:bg-zinc-900",
           className
         )}
         ref={ref}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -10,14 +10,20 @@ const SelectGroup = SelectPrimitive.Group
 
 const SelectValue = SelectPrimitive.Value
 
+export interface SelectTriggerProps
+  extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> {
+  isAutoFilled?: boolean
+}
+
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  SelectTriggerProps
+>(({ className, children, isAutoFilled, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
       "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      isAutoFilled && "border-green-400 bg-green-50 dark:bg-zinc-900",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -3,14 +3,17 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  isAutoFilled?: boolean
+}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, isAutoFilled, ...props }, ref) => {
     return (
       <textarea
         className={cn(
           "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          isAutoFilled && "border-green-400 bg-green-50 dark:bg-zinc-900",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- add `isAutoFilled` prop to UI Input, Textarea and SelectTrigger
- use conditional Tailwind classes to show green border and theme-aware background
- update `TransactionEditForm` to pass the new prop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e6cbf65708333b30f56520db96dc0