### PR TITLE
Update toast behavior for transaction save

### DIFF
--- a/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
+++ b/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
@@ -14,6 +14,8 @@ interface SaveOptions {
   learnFromTransaction: (msg: string, txn: Transaction, hint: string) => void;
   navigateBack: () => void;
   silent?: boolean;
+  showPatternToast?: boolean;
+  combineToasts?: boolean;
 }
 
 export function saveTransactionWithLearning(
@@ -29,6 +31,8 @@ export function saveTransactionWithLearning(
     learnFromTransaction,
     navigateBack,
     silent = false,
+    showPatternToast = true,
+    combineToasts = false,
   } = options;
 
   const newTransaction: Transaction = {
@@ -58,7 +62,7 @@ export function saveTransactionWithLearning(
       saveNewTemplate(template, fields, rawMessage);
     }
 
-    if (!silent) {
+    if (!silent && showPatternToast && !combineToasts) {
       toast({
         title: 'Pattern saved for learning',
         description: 'Future similar messages will be recognized automatically',
@@ -112,10 +116,21 @@ export function saveTransactionWithLearning(
   }
 
   if (!silent) {
-    toast({
-      title: isNew ? 'Transaction created' : 'Transaction updated',
-      description: `Your transaction has been successfully ${isNew ? 'created' : 'updated'}`,
-    });
+    if (combineToasts) {
+      let description = `Your transaction has been successfully ${isNew ? 'created' : 'updated'}.`;
+      if (rawMessage && newTransaction.source === 'smart-paste' && showPatternToast) {
+        description += ' Pattern saved for learning.';
+      }
+      toast({
+        title: isNew ? 'Transaction created' : 'Transaction updated',
+        description,
+      });
+    } else {
+      toast({
+        title: isNew ? 'Transaction created' : 'Transaction updated',
+        description: `Your transaction has been successfully ${isNew ? 'created' : 'updated'}`,
+      });
+    }
   }
 
   navigateBack();

--- a/src/pages/AddTransaction.tsx
+++ b/src/pages/AddTransaction.tsx
@@ -26,6 +26,7 @@ const AddTransaction = () => {
       updateTransaction,
       learnFromTransaction,
       navigateBack: () => navigate(-1),
+      combineToasts: true,
     });
   };
 

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -44,6 +44,7 @@ const EditTransaction = () => {
       updateTransaction,
       learnFromTransaction,
       navigateBack: () => navigate(-1),
+      combineToasts: true,
     });
   };
 


### PR DESCRIPTION
## Summary
- allow `saveTransactionWithLearning` to combine pattern and save toasts
- ensure AddTransaction and EditTransaction use a single toast on save

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7521dccc833383672ce63343d12c