### PR TITLE
Add base URL configuration for cloud functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ This project is built with .
 
 Simply open [Lovable](https://lovable.dev/projects/44f11ecc-0e77-4a7d-a302-6102d5d50c2b) and click on Share -> Publish.
 
+## Environment Variables
+
+The app reads configuration from Vite environment variables. The newly added `VITE_CLOUD_FUNCTIONS_BASE_URL` controls where the Firebase Cloud Functions requests are sent.
+
+- **Production URL:** `https://us-central1-xpensia-505ac.cloudfunctions.net`
+- **Local emulator URL:** `http://localhost:5001/xpensia-505ac/us-central1`
+
+Define this variable in your `.env` file when running locally or configure it in your hosting environment.
+
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -39,3 +39,7 @@ export const ENABLE_DEMO_MODE = getEnvironmentVariable('ENABLE_DEMO_MODE', 'fals
 // Configuration options
 export const DEFAULT_CURRENCY = getEnvironmentVariable('DEFAULT_CURRENCY', 'USD');
 export const APP_VERSION = getEnvironmentVariable('APP_VERSION', '1.0.0');
+export const CLOUD_FUNCTIONS_BASE_URL = getEnvironmentVariable(
+  'CLOUD_FUNCTIONS_BASE_URL',
+  'https://us-central1-xpensia-505ac.cloudfunctions.net'
+);

--- a/src/lib/smart-paste-engine/cloudClassifier.ts
+++ b/src/lib/smart-paste-engine/cloudClassifier.ts
@@ -1,5 +1,6 @@
 import { getAuth } from 'firebase/auth';
 import { firebaseApp } from '@/firebase';
+import { CLOUD_FUNCTIONS_BASE_URL } from '@/lib/env';
 
 export async function classifySmsViaCloud(text: string) {
   const auth = getAuth(firebaseApp);
@@ -8,7 +9,7 @@ export async function classifySmsViaCloud(text: string) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5000);
   try {
-    const res = await fetch('/classifySMS', {
+    const res = await fetch(`${CLOUD_FUNCTIONS_BASE_URL}/classifySMS`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- support base URL for Firebase functions through `CLOUD_FUNCTIONS_BASE_URL`
- update cloud classifier to use the new constant
- document `VITE_CLOUD_FUNCTIONS_BASE_URL` in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(not run due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_685e9c50b83c8333ae3d0ef9a5f09a8e