### PR TITLE
Enable CORS for classifySMS cloud function

### DIFF
--- a/functions/functions/package.json
+++ b/functions/functions/package.json
@@ -17,7 +17,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^10.0.2",
-    "firebase-functions": "^3.18.0"
+    "firebase-functions": "^3.18.0",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/functions/functions/src/classifySMS.ts
+++ b/functions/functions/src/classifySMS.ts
@@ -1,31 +1,35 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
+import * as cors from 'cors';
 import { classifyText } from './classifier';
 
 admin.initializeApp();
+const corsHandler = cors({ origin: true });
 
 export const classifySMS = functions
   .region('us-central1')
-  .https.onRequest(async (req, res) => {
-    if (req.method !== 'POST') {
-      res.status(405).send('POST only');
-      return;
-    }
+  .https.onRequest((req, res) => {
+    corsHandler(req, res, async () => {
+      if (req.method !== 'POST') {
+        res.status(405).send('POST only');
+        return;
+      }
 
-    const idToken = req.headers.authorization?.split('Bearer ')[1];
-    try {
-      await admin.auth().verifyIdToken(idToken ?? '');
-    } catch {
-      res.status(401).send('Unauthorized');
-      return;
-    }
+      const idToken = req.headers.authorization?.split('Bearer ')[1];
+      try {
+        await admin.auth().verifyIdToken(idToken ?? '');
+      } catch {
+        res.status(401).send('Unauthorized');
+        return;
+      }
 
-    const { text } = req.body;
-    if (!text) {
-      res.status(400).send('Missing text');
-      return;
-    }
+      const { text } = req.body;
+      if (!text) {
+        res.status(400).send('Missing text');
+        return;
+      }
 
-    const result = await classifyText(text);
-    res.json({ version: 'v1', ...result });
+      const result = await classifyText(text);
+      res.json({ version: 'v1', ...result });
+    });
   });


### PR DESCRIPTION
## Summary
- enable CORS handling in `classifySMS` cloud function
- declare `cors` as a dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint --prefix functions/functions` *(fails: Cannot find package '@eslint/js')*
- `npm run test --prefix functions/functions` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d976ef4833391415f60679242ef