### PR TITLE
Enable automatic SMS transaction imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,9 +32,13 @@ import { isFinancialTransactionMessage } from '@/lib/smart-paste-engine/messageF
 import { App as CapacitorApp } from '@capacitor/app';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import { BackgroundSmsListener } from '@/plugins/BackgroundSmsListenerPlugin';
+import SmsImportService from '@/services/SmsImportService';
+import { ENABLE_SMS_INTEGRATION } from '@/lib/env';
+import { useUser } from './context/UserContext';
 
 function AppWrapper() {
   const navigate = useNavigate();
+  const { user } = useUser();
 
   useEffect(() => {
     const platform = Capacitor.getPlatform();
@@ -165,6 +169,13 @@ function AppWrapper() {
 
     setupSmsListener();
   }, [navigate]);
+
+  useEffect(() => {
+    if (!ENABLE_SMS_INTEGRATION) return;
+    if (user?.preferences?.sms?.autoImport) {
+      SmsImportService.checkForNewMessages(navigate);
+    }
+  }, [user, navigate]);
 
   return (
     <Routes>

--- a/src/context/user/UserContext.tsx
+++ b/src/context/user/UserContext.tsx
@@ -188,16 +188,19 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
             theme: 'light',
             notifications: true,
             language: 'en',
-            displayOptions: {
-              showCents: true,
-              weekStartsOn: 'sunday',
-              defaultView: 'list',
-              compactMode: false,
-              showCategories: true,
-              showTags: true
-            }
+          displayOptions: {
+            showCents: true,
+            weekStartsOn: 'sunday',
+            defaultView: 'list',
+            compactMode: false,
+            showCategories: true,
+            showTags: true
+          },
+          sms: {
+            autoImport: false
           }
-        };
+        }
+      };
         return newUser;
       }
       

--- a/src/context/user/auth-utils.ts
+++ b/src/context/user/auth-utils.ts
@@ -96,6 +96,9 @@ export const getUserFromLocalStorage = (): User | null => {
             compactMode: false,
             showCategories: true,
             showTags: true
+          },
+          sms: {
+            autoImport: false
           }
         };
       }

--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -10,6 +10,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { Capacitor } from '@capacitor/core';
 import { useNavigate } from 'react-router-dom';
 import { extractVendorName, inferIndirectFields } from '@/lib/smart-paste-engine/suggestionEngine';
+import { setSelectedSmsSenders } from '@/utils/storage-utils';
 import Layout from '@/components/Layout';
 import { isFinancialTransactionMessage } from '@/lib/smart-paste-engine/messageFilter';
 
@@ -168,6 +169,8 @@ const handleReadSms = async () => {
         }
       }
     });
+
+    setSelectedSmsSenders(selectedSenders);
 
     navigate('/vendor-mapping', {
       state: {

--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -18,6 +18,7 @@ import { generateDefaultTitle } from '@/components/TransactionEditForm';
 import { useLocation } from 'react-router-dom';
 import Layout from '@/components/Layout';
 import PageHeader from '@/components/layout/PageHeader';
+import { setLastSmsImportDate } from '@/utils/storage-utils';
 import { getCategoriesForType, getSubcategoriesForCategory} from '@/lib/categories-data';
 import { useTransactions } from '@/context/TransactionContext';
 
@@ -167,6 +168,8 @@ const handleFieldChange = (index: number, field: keyof DraftTransaction, value: 
       title: 'Saved',
       description: `${validTransactions.length} transaction(s) saved successfully.`,
     });
+
+    setLastSmsImportDate(new Date().toISOString());
 
     setTransactions([]);
   };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,7 +8,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
-import { Download, UploadCloud, RefreshCw, Shield, Sun, Moon, Trash, Bell, Database, Eye, Globe, Languages } from 'lucide-react';
+import { Download, UploadCloud, RefreshCw, Shield, Sun, Moon, Trash, Bell, Database, Eye, Globe, Languages, MessageSquare } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
 import { useUser } from '@/context/UserContext';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -589,6 +589,28 @@ const Settings = () => {
                       </Button>
                     </div>
                   </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="border border-border shadow-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <MessageSquare className="mr-2" size={20} />
+                  <span>SMS Import</span>
+                </CardTitle>
+                <CardDescription>Automatically import new SMS messages</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="auto-sms-import">Automatic SMS import</Label>
+                    <p className="text-sm text-muted-foreground">Check for new SMS on startup</p>
+                  </div>
+                  <Switch
+                    id="auto-sms-import"
+                    checked={!!user?.preferences?.sms?.autoImport}
+                    onCheckedChange={(checked) => updateUserPreferences({ sms: { autoImport: checked } })}
+                  />
                 </div>
               </CardContent>
             </Card>

--- a/src/services/SmsImportService.ts
+++ b/src/services/SmsImportService.ts
@@ -1,0 +1,42 @@
+import { SmsReaderService, SmsEntry } from './SmsReaderService';
+import { extractVendorName, inferIndirectFields } from '@/lib/smart-paste-engine/suggestionEngine';
+import { getLastSmsImportDate, getSelectedSmsSenders } from '@/utils/storage-utils';
+
+export class SmsImportService {
+  static async checkForNewMessages(navigate: (path: string, options?: any) => void): Promise<void> {
+    try {
+      const senders = getSelectedSmsSenders();
+      if (senders.length === 0) return;
+
+      const startDateStr = getLastSmsImportDate();
+      const startDate = startDateStr ? new Date(startDateStr) : undefined;
+
+      const messages: SmsEntry[] = await SmsReaderService.readSmsMessages({ startDate, senders });
+      if (!messages || messages.length === 0) return;
+
+      const vendorMap: Record<string, string> = {};
+      const keywordMap: { keyword: string; mappings: { field: string; value: string }[] }[] = [];
+
+      messages.forEach(msg => {
+        const rawVendor = extractVendorName(msg.message);
+        const inferred = inferIndirectFields(msg.message, { vendor: rawVendor });
+        if (rawVendor && !vendorMap[rawVendor]) {
+          vendorMap[rawVendor] = rawVendor;
+          const mappings = [] as { field: string; value: string }[];
+          if (inferred.category) mappings.push({ field: 'category', value: inferred.category });
+          if (inferred.subcategory) mappings.push({ field: 'subcategory', value: inferred.subcategory });
+          if (inferred.type) mappings.push({ field: 'type', value: inferred.type });
+          if (mappings.length > 0) {
+            keywordMap.push({ keyword: rawVendor, mappings });
+          }
+        }
+      });
+
+      navigate('/vendor-mapping', { state: { messages, vendorMap, keywordMap } });
+    } catch (error) {
+      console.error('[SmsImportService] Failed to auto import SMS messages:', error);
+    }
+  }
+}
+
+export default SmsImportService;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -46,5 +46,8 @@ export interface UserPreferences {
     backupFrequency?: 'daily' | 'weekly' | 'monthly';
     dataRetention?: '3months' | '6months' | '1year' | 'forever';
   };
+  sms?: {
+    autoImport?: boolean;
+  };
   updatedAt?: string;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -62,6 +62,7 @@ export interface UserPreferences {
     startDate?: string;
     autoDetectProviders: boolean;
     showDetectionNotifications: boolean;
+    autoImport?: boolean;
   };
   categories?: {
     showUncategorized: boolean;

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -17,6 +17,8 @@ const CATEGORY_CHANGES_STORAGE_KEY = 'xpensia_category_changes';
 const USER_SETTINGS_STORAGE_KEY = 'xpensia_user_settings';
 const LOCALE_SETTINGS_STORAGE_KEY = 'xpensia_locale_settings';
 const STRUCTURE_KEY = 'xpensia_structure_templates';
+const SMS_LAST_IMPORT_KEY = 'xpensia_sms_last_import';
+const SMS_SELECTED_SENDERS_KEY = 'xpensia_sms_selected_senders';
 
 
 // Helper function to safely get data from storage
@@ -377,6 +379,9 @@ export const getUserSettings = (): UserPreferences => {
       autoBackup: false,
       backupFrequency: 'weekly',
       dataRetention: 'forever'
+    },
+    sms: {
+      autoImport: false
     }
   });
 };
@@ -420,4 +425,20 @@ export const updateCurrency = (currency: SupportedCurrency): void => {
     ...localeSettings,
     currency
   });
+};
+
+export const getLastSmsImportDate = (): string | null => {
+  return getFromStorage<string | null>(SMS_LAST_IMPORT_KEY, null);
+};
+
+export const setLastSmsImportDate = (date: string): void => {
+  setInStorage(SMS_LAST_IMPORT_KEY, date);
+};
+
+export const getSelectedSmsSenders = (): string[] => {
+  return getFromStorage<string[]>(SMS_SELECTED_SENDERS_KEY, []);
+};
+
+export const setSelectedSmsSenders = (senders: string[]): void => {
+  setInStorage(SMS_SELECTED_SENDERS_KEY, senders);
 };


### PR DESCRIPTION
## Summary
- add storage helpers for SMS import state
- persist sender selections and last import timestamp
- extend user preferences with SMS auto-import setting
- toggle automatic SMS import in Settings
- implement `SmsImportService` for background message checks
- trigger SMS auto-import on app startup when enabled

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed560341c83339160b85d7c8e2ac3