### PR TITLE
Honor custom SMS date range

### DIFF
--- a/src/services/SmsReaderService.ts
+++ b/src/services/SmsReaderService.ts
@@ -66,18 +66,28 @@ export class SmsReaderService {
       throw new Error('SMS permission not granted');
     }
 
+    // Determine the time range to query. If the caller did not supply a
+    // start date we fall back to the "months back" value stored in local
+    // storage. The end date defaults to "now" if not provided.
     const monthsBack = parseInt(localStorage.getItem('xpensia_sms_period_months') || '6');
-    // Fetch limit to pass to the native plugin. Allows overriding via localStorage.
-    // Defaults to 500 messages which is higher than the plugin's default of 100.
+    // Fetch limit to pass to the native plugin. Allows overriding via
+    // localStorage. Defaults to a large value which is higher than the
+    // plugin's default.
     const limit = parseInt(localStorage.getItem('xpensia_sms_fetch_limit') || '500000');
-    const startDate = subMonths(startOfToday(), monthsBack).getTime();
-    const endDate = Date.now();
+
+    const startDate = (options.startDate
+      ? options.startDate
+      : subMonths(startOfToday(), monthsBack)
+    ).getTime();
+    const endDate = (options.endDate ? options.endDate : new Date()).getTime();
+
     console.log(`[SmsReaderService] Filtering from ${new Date(startDate).toISOString()} to ${new Date(endDate).toISOString()}`);
     console.log(`[SmsReaderService] Scanning for messages between ${new Date(startDate).toLocaleString()} and ${new Date(endDate).toLocaleString()}`);
 
     try {
+      const { senders } = options;
       const result = await SmsReader.readSmsMessages({
-        ...options,
+        senders,
         startDate: String(startDate),
         endDate: String(endDate),
         limit,


### PR DESCRIPTION
## Summary
- ensure SmsReaderService respects provided start/end dates
- convert plugin timestamp parameters to strings

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_685f0961062883338ffb93fb844f8db7