### PR TITLE
Add sender category rule checkbox

### DIFF
--- a/src/lib/smart-paste-engine/senderCategoryRules.ts
+++ b/src/lib/smart-paste-engine/senderCategoryRules.ts
@@ -1,0 +1,27 @@
+export interface SenderCategoryRule {
+  category: string;
+  subcategory: string;
+}
+
+const KEY = 'xpensia_sender_category_rules';
+
+export function loadSenderCategoryRules(): Record<string, SenderCategoryRule> {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    console.error('[SenderCategoryRules] Failed to load rules', err);
+    return {};
+  }
+}
+
+export function saveSenderCategoryRules(rules: Record<string, SenderCategoryRule>): void {
+  localStorage.setItem(KEY, JSON.stringify(rules));
+}
+
+export function learnVendorCategoryRule(sender: string, category: string, subcategory: string): void {
+  if (!sender) return;
+  const rules = loadSenderCategoryRules();
+  rules[sender] = { category, subcategory };
+  saveSenderCategoryRules(rules);
+}


### PR DESCRIPTION
## Summary
- add senderCategoryRules util to persist category rules by sender
- add checkbox to ReviewSmsTransactions for applying category selection to sender
- call rule learning when checkbox toggled and when saving

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685f21a8816c83339f031efd6225a005