### PR TITLE
Add feedback UI for auto-filled fields

### DIFF
--- a/src/utils/suggestions-feedback-log.ts
+++ b/src/utils/suggestions-feedback-log.ts
@@ -1,0 +1,27 @@
+export interface SuggestionsFeedbackEntry {
+  field: string;
+  positive: boolean;
+  value?: any;
+  timestamp: string;
+}
+
+const KEY = 'suggestionsFeedbackLog';
+
+export const getSuggestionsFeedbackLog = (): SuggestionsFeedbackEntry[] => {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const addSuggestionsFeedbackEntry = (entry: SuggestionsFeedbackEntry) => {
+  const log = getSuggestionsFeedbackLog();
+  log.push(entry);
+  try {
+    localStorage.setItem(KEY, JSON.stringify(log));
+  } catch {
+    // ignore write errors
+  }
+};


### PR DESCRIPTION
## Summary
- capture user feedback for auto-filled values
- record feedback to `suggestionsFeedbackLog`

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685f21abdc5883338b101937f1a89f1d