### PR TITLE
Fix map syntax closing in ReviewSmsTransactions

### DIFF
--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -431,7 +431,8 @@ const handleAlwaysApplyChange = (index: number, checked: boolean) => {
             </Button>
           </div>
         </Card>
-      ))}
+      );
+      })}
 
       {allHighConfidence && (
         <AlertDialog>


### PR DESCRIPTION
## Summary
- close `transactions.map` properly in `ReviewSmsTransactions` to fix syntax error

## Testing
- `npm run build` *(fails: `vite` not found)*
- `npm install` *(fails: connect ENETUNREACH github.com)*

------
https://chatgpt.com/codex/tasks/task_e_685f274c1f888333a3eba045222b3a33