### PR TITLE
Fix closing tags in ProcessSmsMessages

### DIFF
--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -375,7 +375,6 @@ const handleReadSms = async () => {
           });
         }}
       />
-      </div>
     </Layout>
   );
 };

--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -431,7 +431,8 @@ const handleAlwaysApplyChange = (index: number, checked: boolean) => {
             </Button>
           </div>
         </Card>
-      ))}
+      );
+      })}
 
       {allHighConfidence && (
         <AlertDialog>


### PR DESCRIPTION
## Summary
- close `transactions.map` properly in `ReviewSmsTransactions`
- remove stray closing div in `ProcessSmsMessages`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: connect ENETUNREACH github.com)*

------
https://chatgpt.com/codex/tasks/task_e_685f274c1f888333a3eba045222b3a33