### PR TITLE
Fix closing tags in ProcessSmsMessages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@capacitor/filesystem": "^7.0.1",
         "@capacitor/ios": "^7.1.0",
         "@capacitor/local-notifications": "^7.0.1",
+        "@capacitor/preferences": "^7.0.1",
         "@capacitor/status-bar": "^7.0.1",
         "@hookform/resolvers": "^3.9.0",
         "@huggingface/transformers": "^3.4.2",
@@ -558,6 +559,15 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-7.0.1.tgz",
       "integrity": "sha512-GJewoiqiTLXNNRxqeJDi6vxj1Y37jLFI3KSdAM2Omvxew4ewyBSCjwOtXMQaEg+lvzGHtK6FPrSc2v/2EcL0wA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-7.0.1.tgz",
+      "integrity": "sha512-XF9jOHzvoIBZLwZr/EX6aVaUO1d8Mx7TwBLQS33pYHOliCW5knT5KUkFOXNNYxh9qqODYesee9xuQIKNJpQBag==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@capacitor/filesystem": "^7.0.1",
     "@capacitor/ios": "^7.1.0",
     "@capacitor/local-notifications": "^7.0.1",
+    "@capacitor/preferences": "^7.0.1",
     "@capacitor/status-bar": "^7.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@huggingface/transformers": "^3.4.2",

--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -375,7 +375,6 @@ const handleReadSms = async () => {
           });
         }}
       />
-      </div>
     </Layout>
   );
 };

--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -431,7 +431,8 @@ const handleAlwaysApplyChange = (index: number, checked: boolean) => {
             </Button>
           </div>
         </Card>
-      ))}
+      );
+      })}
 
       {allHighConfidence && (
         <AlertDialog>


### PR DESCRIPTION
## Summary
- close `transactions.map` properly in `ReviewSmsTransactions`
- remove stray closing div in `ProcessSmsMessages`
- add missing Capacitor `preferences` dependency

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f274c1f888333a3eba045222b3a33