### PR TITLE
Enhance SMS import UI

### DIFF
--- a/src/components/settings/LearningEngineSettings.tsx
+++ b/src/components/settings/LearningEngineSettings.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Brain, Trash2, Database, Settings2 } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -84,6 +85,7 @@ const LearningEngineSettings = () => {
   };
 
   return (
+    <>
     <Card className="mb-6">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
@@ -190,6 +192,22 @@ const LearningEngineSettings = () => {
         </div>
       </CardContent>
     </Card>
+
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Settings2 className="h-5 w-5" />
+          Custom Parsing Rules
+        </CardTitle>
+        <CardDescription>Define your own message parsing rules</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button asChild className="w-full">
+          <Link to="/custom-parsing-rules">Manage Rules</Link>
+        </Button>
+      </CardContent>
+    </Card>
+    </>
   );
 };
 

--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -284,35 +284,41 @@ const handleReadSms = async () => {
       )}
 
       {senders.length > 0 && (
-        <div className="mb-6">
-          <h2 className="text-lg font-semibold mb-2">Select Senders:</h2>
-          <p className="text-sm text-muted-foreground mb-4">
-            Choose the senders whose messages you want to analyze.
-          </p>
-          {senders.map((sender) => (
-            <label
-              key={sender}
-              className="flex items-center mb-2 p-2 rounded-md border cursor-pointer"
-            >
-              <Input
-                type="checkbox"
-                checked={selectedSenders.includes(sender)}
-                onChange={() => toggleSenderSelect(sender)}
-                className="mr-2 dark:bg-white dark:text-black"
-              />
-              {sender}
-            </label>
-          ))}
+        <Accordion type="single" collapsible defaultValue="senders" className="mb-6">
+          <AccordionItem value="senders">
+            <AccordionTrigger className="text-lg font-semibold">Select Senders</AccordionTrigger>
+            <AccordionContent>
+              <p className="text-sm text-muted-foreground mb-4">
+                Choose the senders whose messages you want to analyze.
+              </p>
+              <div className="grid grid-cols-2 gap-2">
+                {senders.map((sender) => (
+                  <label
+                    key={sender}
+                    className="flex items-center p-2 rounded-md border cursor-pointer gap-2"
+                  >
+                    <Input
+                      type="checkbox"
+                      checked={selectedSenders.includes(sender)}
+                      onChange={() => toggleSenderSelect(sender)}
+                      className="dark:bg-white dark:text-black"
+                    />
+                    <span className="text-sm break-words">{sender}</span>
+                  </label>
+                ))}
+              </div>
 
-          <div className="flex flex-col gap-2 mt-4">
-            <Button className="w-full" onClick={handleProceed}>
-              Proceed to Vendor Mapping
-            </Button>
-            <Button variant="outline" className="w-full" onClick={() => setMapOpen(true)}>
-              Quick Map &amp; Review
-            </Button>
-          </div>
-        </div>
+              <div className="flex flex-col gap-2 mt-4">
+                <Button className="w-full" onClick={handleProceed}>
+                  Proceed to Vendor Mapping
+                </Button>
+                <Button variant="outline" className="w-full" onClick={() => setMapOpen(true)}>
+                  Quick Map &amp; Review
+                </Button>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       )}
 
       <div className="space-y-4 pt-4 pb-24">

--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -410,14 +410,14 @@ const handleAlwaysApplyChange = (index: number, checked: boolean) => {
                   : (txn.fieldConfidences?.type ?? 0) >= 0.4
                     ? 'border border-amber-500'
                     : 'border border-red-500'
-              }`}
+              } col-span-2`}
             >
               <ToggleGroupItem value="expense">Expense</ToggleGroupItem>
               <ToggleGroupItem value="income">Income</ToggleGroupItem>
               <ToggleGroupItem value="transfer">Transfer</ToggleGroupItem>
             </ToggleGroup>
           </div>
-          <div className="flex justify-end mt-2">
+          <div className="flex justify-end mt-2 col-span-2">
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
## Summary
- collapse sender list in SMS import page and show checkboxes in a compact grid
- improve transaction review layout so type selector sits above the Full Form button
- add link to the Custom Parsing Rules screen under Learning settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbd5bed688333a8d972c01bb62b01