### PR TITLE
Add confirmation alerts for auto SMS import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -201,7 +201,7 @@ function AppWrapper() {
   useEffect(() => {
     if (!ENABLE_SMS_INTEGRATION) return;
     if (user?.preferences?.sms?.autoImport) {
-      SmsImportService.checkForNewMessages(navigate);
+      SmsImportService.checkForNewMessages(navigate, { auto: true });
     }
   }, [user, navigate]);
 

--- a/src/services/SmsImportService.ts
+++ b/src/services/SmsImportService.ts
@@ -3,11 +3,23 @@ import { extractVendorName, inferIndirectFields } from '@/lib/smart-paste-engine
 import { getSelectedSmsSenders, getSmsSenderImportMap } from '@/utils/storage-utils';
 
 export class SmsImportService {
-  static async checkForNewMessages(navigate: (path: string, options?: any) => void): Promise<void> {
+  static async checkForNewMessages(
+    navigate: (path: string, options?: any) => void,
+    opts?: { auto?: boolean }
+  ): Promise<void> {
     console.log('AIS-02 checkForNewMessages');
     try {
+      const { auto = false } = opts || {};
+
       const senders = getSelectedSmsSenders();
       if (senders.length === 0) return;
+
+      if (auto) {
+        const proceed = window.confirm(
+          'Automatically import new SMS messages from your saved senders?'
+        );
+        if (!proceed) return;
+      }
 
       const senderMap = getSmsSenderImportMap();
 
@@ -35,6 +47,14 @@ export class SmsImportService {
       });
 
       if (filteredMessages.length === 0) return;
+
+      if (auto) {
+        window.alert(
+          `Auto import will process ${filteredMessages.length} messages from ${senders.join(
+            ', '
+          )} since ${startDate.toLocaleDateString()}. Additional senders can be added via manual import.`
+        );
+      }
 
       const vendorMap: Record<string, string> = {};
       const keywordMap: { keyword: string; mappings: { field: string; value: string }[] }[] = [];


### PR DESCRIPTION
## Summary
- add optional `auto` param to `SmsImportService.checkForNewMessages`
- show confirmation and summary alerts when auto-import runs
- update call site in `App.tsx`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ff8d9eb2c8333ace7a41ffe92d9ec