### PR TITLE
Fix vendor mapping init on revisit

### DIFF
--- a/src/pages/VendorMapping.tsx
+++ b/src/pages/VendorMapping.tsx
@@ -38,7 +38,18 @@ const VendorMapping: React.FC = () => {
   const location = useLocation();
   const { toast } = useToast();
   const navigate = useNavigate();
- 
+
+  // Redirect if this page was accessed directly without state
+  useEffect(() => {
+    if (!location.state) {
+      toast({
+        variant: 'destructive',
+        title: 'Missing vendor data',
+        description: 'Please reprocess SMS messages.',
+      });
+      navigate(-1);
+    }
+  }, [location.state, navigate, toast]);
 
   useEffect(() => {
     const incomingVendorMap = location.state?.vendorMap || {};
@@ -91,7 +102,7 @@ const VendorMapping: React.FC = () => {
     });
 
     setVendors(initialMappings);
-  }, []);
+  }, [location.state]);
 
   const handleVendorChange = (index: number, field: keyof VendorMappingEntry, value: string) => {
     setVendors(prev => {
@@ -131,6 +142,10 @@ const handleConfirm = () => {
   const handleRetry = () => {
     navigate('/process-sms');
   };
+
+  if (!location.state) {
+    return null;
+  }
 
   return (
     <Layout>


### PR DESCRIPTION
## Summary
- re-run VendorMapping initialization when navigation state changes
- redirect to previous page if VendorMapping is opened without state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601442cc8483338bbb6db037492c62