### PR TITLE
Fix SMS auto import cancellation

### DIFF
--- a/src/pages/VendorMapping.tsx
+++ b/src/pages/VendorMapping.tsx
@@ -206,7 +206,7 @@ const handleConfirm = () => {
         </Accordion>
       </div>
 
-      <div className="fixed bottom-16 left-0 right-0 px-4 flex gap-4 z-20">
+      <div className="fixed bottom-16 left-0 right-0 px-4 flex gap-4 z-40">
         <Button className="flex-1" variant="outline" onClick={handleRetry}>
           Retry
         </Button>


### PR DESCRIPTION
## Summary
- track if the user cancels the auto-import prompt so it isn't shown again
- keep vendor mapping controls above bottom nav

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68601003f9b48333b63dd49d4c84fda3