### PR TITLE
Add persistent profile image hook

### DIFF
--- a/src/hooks/useProfileImage.ts
+++ b/src/hooks/useProfileImage.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { Camera, CameraResultType, CameraSource } from '@capacitor/camera';
+import { Filesystem, Directory } from '@capacitor/filesystem';
+
+const PROFILE_IMAGE_KEY = 'profileImagePath';
+
+export function useProfileImage() {
+  const [image, setImage] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadSavedImage();
+  }, []);
+
+  const takeOrSelectPhoto = async () => {
+    const photo = await Camera.getPhoto({
+      resultType: CameraResultType.Uri,
+      source: CameraSource.Prompt,
+      quality: 80
+    });
+
+    const base64Data = await convertWebPathToBase64(photo.webPath!);
+
+    const fileName = 'profile.jpg';
+
+    await Filesystem.writeFile({
+      path: fileName,
+      data: base64Data,
+      directory: Directory.Data
+    });
+
+    localStorage.setItem(PROFILE_IMAGE_KEY, fileName);
+    setImage(`data:image/jpeg;base64,${base64Data}`);
+  };
+
+  const loadSavedImage = async () => {
+    const fileName = localStorage.getItem(PROFILE_IMAGE_KEY);
+    if (!fileName) return;
+
+    try {
+      const result = await Filesystem.readFile({
+        path: fileName,
+        directory: Directory.Data
+      });
+      setImage(`data:image/jpeg;base64,${result.data}`);
+    } catch (err) {
+      console.error('Failed to load profile image:', err);
+      setImage(null);
+    }
+  };
+
+  return {
+    image,              // base64 string to be used as <img src={image} />
+    takeOrSelectPhoto   // call this to update profile image
+  };
+}
+
+async function convertWebPathToBase64(webPath: string): Promise<string> {
+  const response = await fetch(webPath);
+  const blob = await response.blob();
+  return await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const base64 = reader.result?.toString().split(',')[1];
+      if (base64) resolve(base64);
+      else reject('Unable to convert image to base64');
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Camera, Trash2 } from 'lucide-react';
 import Layout from '@/components/Layout';
@@ -30,9 +30,12 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 
+import { useProfileImage } from '@/hooks/useProfileImage';
+
 const Profile = () => {
   const { user, updateUser } = useUser();
   const { toast } = useToast();
+  const { image, takeOrSelectPhoto } = useProfileImage();
   const [isEditing, setIsEditing] = useState(false);
   const [editFormData, setEditFormData] = useState({
     fullName: user?.fullName || '',
@@ -40,6 +43,12 @@ const Profile = () => {
     phone: user?.phone || '',
     avatar: user?.avatar,
   });
+
+  useEffect(() => {
+    if (image) {
+      updateUser({ avatar: image });
+    }
+  }, [image, updateUser]);
 
   const handleSaveProfile = () => {
     if (!editFormData.fullName.trim()) {
@@ -62,19 +71,6 @@ const Profile = () => {
     setEditFormData({ ...editFormData, [name]: value });
   };
 
-  const handleAvatarUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      const dataUrl = reader.result as string;
-      setEditFormData({ ...editFormData, avatar: dataUrl });
-      updateUser({ avatar: dataUrl });
-      toast({ title: 'Avatar updated', description: 'Your profile picture has been updated.' });
-    };
-    reader.readAsDataURL(file);
-  };
 
   const handleDeleteAccount = () => {
     toast({
@@ -126,22 +122,16 @@ const Profile = () => {
         <div className="bg-card rounded-lg border p-6 flex flex-col items-center text-center space-y-4">
           <div className="relative">
             <Avatar className="h-24 w-24">
-              <AvatarImage src={user?.avatar || '/placeholder.svg'} alt={user?.fullName || 'User'} />
+              <AvatarImage src={image ?? user?.avatar || '/placeholder.svg'} alt={user?.fullName || 'User'} />
               <AvatarFallback>{user?.fullName?.charAt(0) || 'U'}</AvatarFallback>
             </Avatar>
-            <label
-              htmlFor="avatar-upload"
+            <button
+              type="button"
+              onClick={takeOrSelectPhoto}
               className="absolute bottom-0 right-0 bg-primary text-primary-foreground h-8 w-8 rounded-full flex items-center justify-center cursor-pointer hover:bg-primary/90 transition-colors"
             >
               <Camera size={14} />
-              <Input
-                id="avatar-upload"
-                type="file"
-                accept="image/*"
-                className="hidden dark:bg-white dark:text-black"
-                onChange={handleAvatarUpload}
-              />
-            </label>
+            </button>
           </div>
 
           <div className="space-y-1">


### PR DESCRIPTION
## Summary
- save & load profile photo using Capacitor filesystem in new hook
- use persistent image in `Profile` page with camera button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860263ef6808333942b63a68131b041