### PR TITLE
Fix auto-import loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,10 @@ import { getQueuedMessages, clearQueuedMessages } from '@/services/smsQueueServi
 
 function AppWrapper() {
   const navigate = useNavigate();
+  const navigateRef = React.useRef(navigate);
+  useEffect(() => {
+    navigateRef.current = navigate;
+  }, [navigate]);
   const { user } = useUser();
   const [queueOpen, setQueueOpen] = useState(false);
   const [queuedMessages, setQueuedMessages] = useState<{ sender: string; body: string }[]>([]);
@@ -201,9 +205,9 @@ function AppWrapper() {
   useEffect(() => {
     if (!ENABLE_SMS_INTEGRATION) return;
     if (user?.preferences?.sms?.autoImport) {
-      SmsImportService.checkForNewMessages(navigate, { auto: true });
+      SmsImportService.checkForNewMessages(navigateRef.current, { auto: true });
     }
-  }, [user, navigate]);
+  }, [user]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- ensure `SmsImportService.checkForNewMessages` only runs when the user changes
- store `navigate` in a ref so navigation persists across renders

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68603d73ea0c83338a10e150af7eba65