### PR TITLE
Align SmartPaste callback data

### DIFF
--- a/src/components/NERSmartPaste.tsx
+++ b/src/components/NERSmartPaste.tsx
@@ -24,8 +24,11 @@ interface NERSmartPasteProps {
     rawMessage?: string,
     senderHint?: string,
     confidence?: number,
-    shouldTrain?: boolean,
-    matchOrigin?: "template" | "structure" | "ml" | "fallback"
+    matchOrigin?: "template" | "structure" | "ml" | "fallback",
+    matchedCount?: number,
+    totalTemplates?: number,
+    fieldScore?: number,
+    keywordScore?: number
   ) => void;
 }
 
@@ -80,7 +83,17 @@ const handleSubmit = async (e: React.FormEvent) => {
 
     if (onTransactionsDetected) {
       console.log('[NER] Final transaction:', transaction);
-      onTransactionsDetected([transaction], text, senderHint);
+      onTransactionsDetected(
+        [transaction],
+        text,
+        senderHint,
+        0.9,
+        'ml',
+        0,
+        0,
+        undefined,
+        undefined
+      );
     }
   } catch (err: any) {
     console.error('[NER] Extraction error:', err);
@@ -122,7 +135,17 @@ const handleSubmit = async (e: React.FormEvent) => {
     
     console.log('[NER] Transaction added:', transaction);
     if (onTransactionsDetected) {
-      onTransactionsDetected([transaction], text, senderHint);
+      onTransactionsDetected(
+        [transaction],
+        text,
+        senderHint,
+        0.9,
+        'ml',
+        0,
+        0,
+        undefined,
+        undefined
+      );
     }
 
     toast({

--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -22,8 +22,11 @@ interface SmartPasteProps {
     rawMessage?: string,
     senderHint?: string,
     confidence?: number,
-    shouldTrain?: boolean,
-    matchOrigin?: "template" | "structure" | "ml" | "fallback"
+    matchOrigin?: "template" | "structure" | "ml" | "fallback",
+    matchedCount?: number,
+    totalTemplates?: number,
+    fieldScore?: number,
+    keywordScore?: number
   ) => void;
 }
 
@@ -103,7 +106,11 @@ const handleSubmit = async (e: React.FormEvent) => {
       origin,
       parsed,
       fieldConfidences,
-      parsingStatus
+      parsingStatus,
+      matchedCount,
+      totalTemplates,
+      fieldScore,
+      keywordScore
     } = await parseAndInferTransaction(text, senderHint);
 
     console.log("[SmartPaste] Parsed result:", parsed);
@@ -123,8 +130,11 @@ const handleSubmit = async (e: React.FormEvent) => {
         text,
         transaction.fromAccount,
         confidence,
-        origin === 'template' || origin === 'ml',
-        origin
+        origin,
+        matchedCount,
+        totalTemplates,
+        fieldScore,
+        keywordScore
       );
     }
   } catch (err: any) {
@@ -167,7 +177,17 @@ const handleSubmit = async (e: React.FormEvent) => {
     
     console.log("[SmartPaste] Transaction added:", transaction);
     if (onTransactionsDetected) {
-      onTransactionsDetected([transaction], text, senderHint, 0.95, true, 'structure');
+      onTransactionsDetected(
+        [transaction],
+        text,
+        senderHint,
+        0.95,
+        'structure',
+        0,
+        0,
+        undefined,
+        undefined
+      );
     }
 
     toast({

--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -19,6 +19,10 @@ export interface ParsedTransactionResult {
   parsed: ReturnType<typeof parseSmsMessage>;
   fieldConfidences: Record<string, number>;
   parsingStatus: 'success' | 'partial' | 'failed';
+  matchedCount: number;
+  totalTemplates: number;
+  fieldScore: number;
+  keywordScore: number;
 }
 
 /**
@@ -115,6 +119,10 @@ export async function parseAndInferTransaction(
         parsed,
         fieldConfidences,
         parsingStatus: cloudStatus,
+        matchedCount: matchedTemplates,
+        totalTemplates: templates.length,
+        fieldScore,
+        keywordScore,
       };
     } catch (err) {
       console.warn('Cloud classifier failed:', err);
@@ -132,5 +140,9 @@ export async function parseAndInferTransaction(
     parsed,
     fieldConfidences,
     parsingStatus,
+    matchedCount: matchedTemplates,
+    totalTemplates: templates.length,
+    fieldScore,
+    keywordScore,
   };
 }

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -90,6 +90,8 @@ const EditTransaction = () => {
               confidence={confidenceScore}
               matchedCount={location.state.matchedCount}
               totalTemplates={location.state.totalTemplates}
+              fieldScore={location.state.fieldScore}
+              keywordScore={location.state.keywordScore}
             />
           )}
 

--- a/src/pages/ImportTransactions.tsx
+++ b/src/pages/ImportTransactions.tsx
@@ -12,14 +12,14 @@ const ImportTransactions = () => {
 
   const handleTransactionsDetected = (
     transactions: Transaction[],
-	  rawMessage?: string,
-	  senderHint?: string,
-	  confidence?: number,
-	  matchOrigin?: 'template' | 'structure' | 'ml' | 'fallback',
-	  matchedCount?: number,
-	  totalTemplates?: number,
-	  fieldScore?: number,
-	  keywordScore?: number
+    rawMessage?: string,
+    senderHint?: string,
+    confidence?: number,
+    matchOrigin?: 'template' | 'structure' | 'ml' | 'fallback',
+    matchedCount?: number,
+    totalTemplates?: number,
+    fieldScore?: number,
+    keywordScore?: number
   ) => {
     console.log('[ImportTransactions] Transactions detected', {
       count: transactions.length,

--- a/src/pages/ImportTransactionsNER.tsx
+++ b/src/pages/ImportTransactionsNER.tsx
@@ -15,14 +15,14 @@ const ImportTransactionsNER = () => {
 
   const handleTransactionsDetected = (
     transactions: Transaction[],
-	  rawMessage?: string,
-	  senderHint?: string,
-	  confidence?: number,
-	  matchOrigin?: 'template' | 'structure' | 'ml' | 'fallback',
-	  matchedCount?: number,
-	  totalTemplates?: number,
-	  fieldScore?: number,
-	  keywordScore?: number
+    rawMessage?: string,
+    senderHint?: string,
+    confidence?: number,
+    matchOrigin?: 'template' | 'structure' | 'ml' | 'fallback',
+    matchedCount?: number,
+    totalTemplates?: number,
+    fieldScore?: number,
+    keywordScore?: number
   ) => {
     console.log('[ImportTransactionsNER] Transactions detected', {
       count: transactions.length,


### PR DESCRIPTION
## Summary
- extend `ParsedTransactionResult` with additional scoring info
- unify SmartPaste and NERSmartPaste callback parameters
- pass scoring data when navigating from import pages
- show field and keyword scores in EditTransaction

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604a97e8648333afb2bc32bd61e6a6