### PR TITLE
Remove redundant Save All button

### DIFF
--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -480,9 +480,6 @@ const handleSkip = (index: number) => {
         </AlertDialog>
       )}
 
-      <Button className="w-full mt-4" onClick={handleSave}>
-        Save All
-      </Button>
     </Layout>
   );
 };


### PR DESCRIPTION
## Summary
- remove the bottom "Save All" button from the SMS review screen

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604de2013c833397ea625f01dcd280