### PR TITLE
Align storage key with TransactionContext

### DIFF
--- a/src/components/settings/DataManagementSettings.tsx
+++ b/src/components/settings/DataManagementSettings.tsx
@@ -8,7 +8,12 @@ import { Switch } from '@/components/ui/switch';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { Download, UploadCloud, RefreshCw, Database } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
-import { getUserSettings, storeUserSettings } from '@/utils/storage-utils';
+import {
+  getUserSettings,
+  storeUserSettings,
+  getStoredTransactions,
+  storeTransactions
+} from '@/utils/storage-utils';
 
 // Define the correct types for backupFrequency and dataRetention
 type BackupFrequency = 'daily' | 'weekly' | 'monthly' | 'never';
@@ -90,8 +95,8 @@ const DataManagementSettings = () => {
   
   const handleExportData = () => {
     try {
-      const data = localStorage.getItem('transactions');
-      if (!data) {
+      const transactions = getStoredTransactions();
+      if (!transactions.length) {
         toast({
           title: "No data to export",
           description: "You don't have any transactions to export.",
@@ -99,8 +104,10 @@ const DataManagementSettings = () => {
         });
         return;
       }
-      
-      const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(data);
+
+      const dataStr =
+        "data:text/json;charset=utf-8," +
+        encodeURIComponent(JSON.stringify(transactions));
       const downloadAnchorNode = document.createElement('a');
       downloadAnchorNode.setAttribute("href", dataStr);
       downloadAnchorNode.setAttribute("download", "expense-tracker-data.json");
@@ -136,7 +143,7 @@ const DataManagementSettings = () => {
       reader.onload = (event) => {
         try {
           const jsonData = JSON.parse(event.target?.result as string);
-          localStorage.setItem('transactions', JSON.stringify(jsonData));
+          storeTransactions(jsonData);
           toast({
             title: "Import successful",
             description: "Your data has been imported successfully.",
@@ -158,7 +165,7 @@ const DataManagementSettings = () => {
   };
   
   const handleResetData = () => {
-    localStorage.removeItem('transactions');
+    localStorage.removeItem('xpensia_transactions');
     toast({
       title: "Data reset successful",
       description: "All your transaction data has been reset.",

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Layout from '@/components/Layout';
 import PageHeader from '@/components/layout/PageHeader';
 import { useTransactions } from '@/context/TransactionContext';
+import { getStoredTransactions } from '@/utils/storage-utils';
 import {
   ToggleGroup,
   ToggleGroupItem
@@ -142,12 +143,12 @@ const Analytics: React.FC = () => {
   const randomTip = React.useMemo(() => tips[Math.floor(Math.random() * tips.length)], []);
 
   const handleExport = () => {
-    const data = localStorage.getItem('transactions');
-    if (!data) {
+    const transactions = getStoredTransactions();
+    if (!transactions.length) {
       toast({ title: 'No data to export' });
       return;
     }
-    const blob = new Blob([data], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(transactions)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -19,6 +19,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel } from '@/components/ui/form';
 import { useForm } from 'react-hook-form';
 import { CURRENCIES } from '@/lib/categories-data';
+import { getStoredTransactions, storeTransactions } from '@/utils/storage-utils';
 
 const Settings = () => {
   const { toast } = useToast();
@@ -183,7 +184,7 @@ const Settings = () => {
   };
   
   const handleResetData = () => {
-    localStorage.removeItem('transactions');
+    localStorage.removeItem('xpensia_transactions');
     toast({
       title: "Data reset successful",
       description: "All your transaction data has been reset.",
@@ -192,8 +193,8 @@ const Settings = () => {
   };
   
   const handleExportData = () => {
-    const transactions = localStorage.getItem('transactions');
-    if (!transactions) {
+    const transactions = getStoredTransactions();
+    if (!transactions.length) {
       toast({
         title: "No data to export",
         description: "You don't have any transactions to export.",
@@ -201,8 +202,10 @@ const Settings = () => {
       });
       return;
     }
-    
-    const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(transactions);
+
+    const dataStr =
+      "data:text/json;charset=utf-8," +
+      encodeURIComponent(JSON.stringify(transactions));
     const downloadAnchorNode = document.createElement('a');
     downloadAnchorNode.setAttribute("href", dataStr);
     downloadAnchorNode.setAttribute("download", "expense-tracker-data.json");
@@ -224,7 +227,7 @@ const Settings = () => {
     reader.onload = (e) => {
       try {
         const jsonData = JSON.parse(e.target?.result as string);
-        localStorage.setItem('transactions', JSON.stringify(jsonData));
+        storeTransactions(jsonData);
         toast({
           title: "Import successful",
           description: "Your data has been imported successfully.",


### PR DESCRIPTION
## Summary
- use `getStoredTransactions` and `storeTransactions` helpers in settings pages
- update data reset logic to clear `xpensia_transactions` key
- export analytics data via helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604fa2267483338ef36fd3de8ca70d