### PR TITLE
Fix transaction export

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Layout from '@/components/Layout';
 import PageHeader from '@/components/layout/PageHeader';
 import { useTransactions } from '@/context/TransactionContext';
-import { getStoredTransactions } from '@/utils/storage-utils';
 import {
   ToggleGroup,
   ToggleGroupItem
@@ -143,7 +142,8 @@ const Analytics: React.FC = () => {
   const randomTip = React.useMemo(() => tips[Math.floor(Math.random() * tips.length)], []);
 
   const handleExport = () => {
-    const transactions = getStoredTransactions();
+    const data = localStorage.getItem('xpensia_transactions');
+    const transactions = data ? JSON.parse(data) : [];
     if (!transactions.length) {
       toast({ title: 'No data to export' });
       return;


### PR DESCRIPTION
## Summary
- use the `xpensia_transactions` storage key to export the stored transactions in Analytics page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686050ad111483338c7f54c3a46e6a4c