### PR TITLE
Update SMS read logic for per-sender filtering

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -43,3 +43,9 @@ export const CLOUD_FUNCTIONS_BASE_URL = getEnvironmentVariable(
   'CLOUD_FUNCTIONS_BASE_URL',
   'https://us-central1-xpensia-505ac.cloudfunctions.net'
 );
+
+// Default SMS look-back period (in months) used when no user preference is set
+export const SMS_LOOKBACK_MONTHS = parseInt(
+  getEnvironmentVariable('SMS_LOOKBACK_MONTHS', '6'),
+  10
+);

--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -11,6 +11,7 @@ import { Capacitor } from '@capacitor/core';
 import { useNavigate } from 'react-router-dom';
 import { extractVendorName, inferIndirectFields } from '@/lib/smart-paste-engine/suggestionEngine';
 import { setSelectedSmsSenders, getSmsSenderImportMap } from '@/utils/storage-utils';
+import { SMS_LOOKBACK_MONTHS } from '@/lib/env';
 import {
   Dialog,
   DialogContent,
@@ -162,16 +163,25 @@ const handleReadSms = async () => {
     const keywordObjects = JSON.parse(localStorage.getItem('xpensia_type_keywords') || '[]') as { keyword: string, type: string }[];
     const keywords = keywordObjects.map(obj => obj.keyword.toLowerCase());
 
-    // Determine start dates for the selected senders based on the
-    // per-sender import map. If a sender has no entry, default to six
-    // months ago. We then use the earliest of those dates when reading
-    // from the device to minimize the query range.
+    // Determine the start date for reading messages. We consult the
+    // per-sender import map and fall back to the default look-back
+    // period. The earliest of these dates is used to minimize the query
+    // range when fetching messages from the device.
     const senderMap = getSmsSenderImportMap();
-    const defaultStart = new Date(new Date().setMonth(new Date().getMonth() - 6));
-    const senderDates = selectedSenders.map(s => senderMap[s] ? new Date(senderMap[s]) : defaultStart);
-    const startDate = senderDates.length > 0 ? new Date(Math.min(...senderDates.map(d => d.getTime()))) : defaultStart;
+    const monthsBack = parseInt(
+      localStorage.getItem('xpensia_sms_period_months') || String(SMS_LOOKBACK_MONTHS),
+      10
+    );
+    const defaultStart = new Date();
+    defaultStart.setMonth(defaultStart.getMonth() - monthsBack);
 
-    const smsMessages = await SmsReaderService.readSmsMessages({ startDate, senders: selectedSenders });
+    const mapDates = Object.values(senderMap).map(d => new Date(d).getTime());
+    const earliestMap = mapDates.length > 0 ? new Date(Math.min(...mapDates)) : null;
+    const startDate = earliestMap && earliestMap.getTime() < defaultStart.getTime()
+      ? earliestMap
+      : defaultStart;
+
+    const smsMessages = await SmsReaderService.readSmsMessages({ startDate });
 
     const validMessages: ProcessedSmsEntry[] = [];
     const invalidMessages: ProcessedSmsEntry[] = [];

--- a/src/services/SmsReaderService.ts
+++ b/src/services/SmsReaderService.ts
@@ -2,6 +2,7 @@
 import { Capacitor } from "@capacitor/core";
 import { SmsReader } from "../plugins/SmsReaderPlugin";
 import { subMonths, startOfToday } from 'date-fns';
+import { SMS_LOOKBACK_MONTHS } from '@/lib/env';
 
 export interface SmsReadOptions {
   startDate?: Date;
@@ -69,7 +70,10 @@ export class SmsReaderService {
     // Determine the time range to query. If the caller did not supply a
     // start date we fall back to the "months back" value stored in local
     // storage. The end date defaults to "now" if not provided.
-    const monthsBack = parseInt(localStorage.getItem('xpensia_sms_period_months') || '6');
+    const monthsBack = parseInt(
+      localStorage.getItem('xpensia_sms_period_months') || String(SMS_LOOKBACK_MONTHS),
+      10
+    );
     // Fetch limit to pass to the native plugin. Allows overriding via
     // localStorage. Defaults to a large value which is higher than the
     // plugin's default.


### PR DESCRIPTION
## Summary
- refactor `ProcessSmsMessages` to fetch all SMS without sender filter
- apply look-back period from storage or env to each sender
- expose `SMS_LOOKBACK_MONTHS` environment variable
- update `SmsReaderService` to use new env variable

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686051828fa88333b6e48cb1ece131b1