### PR TITLE
Add env-configured SMS lookback

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Simply open [Lovable](https://lovable.dev/projects/44f11ecc-0e77-4a7d-a302-6102d
 ## Environment Variables
 
 The app reads configuration from Vite environment variables. The newly added `VITE_CLOUD_FUNCTIONS_BASE_URL` controls where the Firebase Cloud Functions requests are sent.
+`VITE_SMS_LOOKBACK_MONTHS` sets the default number of months of SMS history to scan when importing messages (default `6`).
 
 - **Production URL:** `https://us-central1-xpensia-505ac.cloudfunctions.net`
 - **Local emulator URL:** `http://localhost:5001/xpensia-505ac/us-central1`

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -45,7 +45,33 @@ export const CLOUD_FUNCTIONS_BASE_URL = getEnvironmentVariable(
 );
 
 // Default SMS look-back period (in months) used when no user preference is set
-export const SMS_LOOKBACK_MONTHS = parseInt(
+export const VITE_SMS_LOOKBACK_MONTHS = parseInt(
   getEnvironmentVariable('SMS_LOOKBACK_MONTHS', '6'),
   10
 );
+
+/**
+ * Returns the SMS look-back period in months.
+ *
+ * The value is determined by checking the `xpensia_sms_period_months`
+ * entry in local storage. If no user preference is stored, the
+ * `VITE_SMS_LOOKBACK_MONTHS` environment variable is used and the
+ * value is persisted to local storage for future calls.
+ */
+export const getSmsLookbackMonths = (): number => {
+  try {
+    const stored = localStorage.getItem('xpensia_sms_period_months');
+    if (stored !== null) {
+      const parsed = parseInt(stored, 10);
+      if (!isNaN(parsed)) {
+        return parsed;
+      }
+    } else {
+      localStorage.setItem('xpensia_sms_period_months', String(VITE_SMS_LOOKBACK_MONTHS));
+    }
+  } catch {
+    // Ignore storage errors and fall back to env default
+  }
+
+  return VITE_SMS_LOOKBACK_MONTHS;
+};

--- a/src/pages/ProcessSmsMessages.tsx
+++ b/src/pages/ProcessSmsMessages.tsx
@@ -11,7 +11,7 @@ import { Capacitor } from '@capacitor/core';
 import { useNavigate } from 'react-router-dom';
 import { extractVendorName, inferIndirectFields } from '@/lib/smart-paste-engine/suggestionEngine';
 import { setSelectedSmsSenders, getSmsSenderImportMap } from '@/utils/storage-utils';
-import { SMS_LOOKBACK_MONTHS } from '@/lib/env';
+import { getSmsLookbackMonths } from '@/lib/env';
 import {
   Dialog,
   DialogContent,
@@ -168,10 +168,7 @@ const handleReadSms = async () => {
     // period. The earliest of these dates is used to minimize the query
     // range when fetching messages from the device.
     const senderMap = getSmsSenderImportMap();
-    const monthsBack = parseInt(
-      localStorage.getItem('xpensia_sms_period_months') || String(SMS_LOOKBACK_MONTHS),
-      10
-    );
+    const monthsBack = getSmsLookbackMonths();
     const defaultStart = new Date();
     defaultStart.setMonth(defaultStart.getMonth() - monthsBack);
 

--- a/src/services/SmsReaderService.ts
+++ b/src/services/SmsReaderService.ts
@@ -2,7 +2,7 @@
 import { Capacitor } from "@capacitor/core";
 import { SmsReader } from "../plugins/SmsReaderPlugin";
 import { subMonths, startOfToday } from 'date-fns';
-import { SMS_LOOKBACK_MONTHS } from '@/lib/env';
+import { getSmsLookbackMonths } from '@/lib/env';
 
 export interface SmsReadOptions {
   startDate?: Date;
@@ -70,10 +70,7 @@ export class SmsReaderService {
     // Determine the time range to query. If the caller did not supply a
     // start date we fall back to the "months back" value stored in local
     // storage. The end date defaults to "now" if not provided.
-    const monthsBack = parseInt(
-      localStorage.getItem('xpensia_sms_period_months') || String(SMS_LOOKBACK_MONTHS),
-      10
-    );
+    const monthsBack = getSmsLookbackMonths();
     // Fetch limit to pass to the native plugin. Allows overriding via
     // localStorage. Defaults to a large value which is higher than the
     // plugin's default.


### PR DESCRIPTION
## Summary
- configure `VITE_SMS_LOOKBACK_MONTHS` in env.ts
- add `getSmsLookbackMonths()` helper (env → localStorage)
- use helper in `SmsReaderService` and `ProcessSmsMessages`
- document SMS lookback env var in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686053a7ef308333a776eb4cf8c7c17f