### PR TITLE
Add CSV import support

### DIFF
--- a/src/components/settings/DataManagementSettings.tsx
+++ b/src/components/settings/DataManagementSettings.tsx
@@ -14,7 +14,7 @@ import {
   getStoredTransactions,
   storeTransactions
 } from '@/utils/storage-utils';
-import { convertTransactionsToCsv } from '@/utils/csv';
+import { convertTransactionsToCsv, parseCsvTransactions } from '@/utils/csv';
 
 // Define the correct types for backupFrequency and dataRetention
 type BackupFrequency = 'daily' | 'weekly' | 'monthly' | 'never';
@@ -134,7 +134,7 @@ const DataManagementSettings = () => {
   const handleImportData = () => {
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
-    fileInput.accept = '.json';
+    fileInput.accept = '.json,.csv';
     
     fileInput.onchange = (e) => {
       const target = e.target as HTMLInputElement;
@@ -142,11 +142,18 @@ const DataManagementSettings = () => {
       
       const file = target.files[0];
       const reader = new FileReader();
-      
+
       reader.onload = (event) => {
         try {
-          const jsonData = JSON.parse(event.target?.result as string);
-          storeTransactions(jsonData);
+          const text = event.target?.result as string;
+          const isCsv = file.name.toLowerCase().endsWith('.csv');
+          const data = isCsv ? parseCsvTransactions(text) : JSON.parse(text);
+
+          if (!Array.isArray(data) || data.length === 0) {
+            throw new Error('No valid transactions');
+          }
+
+          storeTransactions(data as any);
           toast({
             title: "Import successful",
             description: "Your data has been imported successfully.",
@@ -155,12 +162,12 @@ const DataManagementSettings = () => {
         } catch (error) {
           toast({
             title: "Import failed",
-            description: "Failed to parse the imported file. Make sure it's a valid JSON file.",
+            description: "Failed to parse the imported file. Make sure it's a valid JSON or CSV file.",
             variant: "destructive",
           });
         }
       };
-      
+
       reader.readAsText(file);
     };
     

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -2,7 +2,8 @@ export interface CsvConversionOptions {
   delimiter?: string;
 }
 
-import { Transaction } from '@/types/transaction';
+import { Transaction, TransactionType, TransactionSource } from '@/types/transaction';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Convert an array of transactions to a CSV string.
@@ -50,4 +51,66 @@ export const convertTransactionsToCsv = (
   );
 
   return [headers.join(delimiter), ...rows].join('\n');
+};
+
+/**
+ * Parse a CSV string into an array of Transaction objects.
+ * Only rows containing the required fields are returned.
+ * Required fields: title, amount, date, type, category
+ */
+export const parseCsvTransactions = (fileData: string): Transaction[] => {
+  if (!fileData) return [];
+
+  const lines = fileData.trim().split(/\r?\n/).filter(l => l.trim().length > 0);
+  if (lines.length < 2) return [];
+
+  const splitRow = (row: string) =>
+    row
+      .split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/)
+      .map(v => v.replace(/^"|"$/g, '').trim());
+
+  const headers = splitRow(lines[0]);
+  const transactions: Transaction[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = splitRow(lines[i]);
+    if (values.length === 0) continue;
+
+    const row: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      row[h] = values[idx];
+    });
+
+    // Validate required fields
+    if (!row.title || !row.amount || !row.date || !row.type || !row.category) {
+      continue;
+    }
+
+    const txn: Transaction = {
+      id: row.id || uuidv4(),
+      title: row.title,
+      amount: parseFloat(row.amount),
+      category: row.category,
+      date: row.date,
+      type: row.type as TransactionType,
+      source: (row.source as TransactionSource) || 'import',
+    };
+
+    if (row.subcategory) txn.subcategory = row.subcategory;
+    if (row.notes) txn.notes = row.notes;
+    if (row.currency) txn.currency = row.currency;
+    if (row.person) txn.person = row.person;
+    if (row.fromAccount) txn.fromAccount = row.fromAccount;
+    if (row.toAccount) txn.toAccount = row.toAccount;
+    if (row.country) txn.country = row.country;
+    if (row.description) txn.description = row.description;
+    if (row.originalCurrency) txn.originalCurrency = row.originalCurrency;
+    if (row.vendor) txn.vendor = row.vendor;
+    if (row.account) txn.account = row.account;
+    if (row.createdAt) txn.createdAt = row.createdAt;
+
+    transactions.push(txn);
+  }
+
+  return transactions;
 };


### PR DESCRIPTION
## Summary
- implement `parseCsvTransactions` to load CSV rows into transactions
- allow importing `.csv` files in data management settings
- parse CSV file during import and show same success/failure toasts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68613ff02ee4833394d8663ec5558b3f