### PR TITLE
Support Saturday as start of week

### DIFF
--- a/src/components/wireframes/screens/SettingsScreen.tsx
+++ b/src/components/wireframes/screens/SettingsScreen.tsx
@@ -20,7 +20,7 @@ interface UserData {
     currency?: string;
     displayOptions?: {
       showCents?: boolean;
-      weekStartsOn?: 'sunday' | 'monday';
+      weekStartsOn?: 'sunday' | 'monday' | 'saturday';
       defaultView?: 'list' | 'stats' | 'calendar';
       compactMode?: boolean;
     };

--- a/src/context/user/types.ts
+++ b/src/context/user/types.ts
@@ -25,7 +25,7 @@ export interface User extends UserType {
     language: string;
     displayOptions?: {
       showCents: boolean;
-      weekStartsOn: "sunday" | "monday";
+      weekStartsOn: "sunday" | "monday" | "saturday";
       defaultView: "list" | "stats" | "calendar";
       compactMode?: boolean;
       showCategories?: boolean;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -107,7 +107,7 @@ export const userPreferencesSchema = z.object({
   }),
   displayOptions: z.object({
     showCents: z.boolean(),
-    weekStartsOn: z.enum(["sunday", "monday"]),
+    weekStartsOn: z.enum(["sunday", "monday", "saturday"]),
     defaultView: z.enum(["list", "stats", "calendar"]),
     compactMode: z.boolean().optional(),
     showCategories: z.boolean().optional(),

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -42,7 +42,7 @@ const Settings = () => {
   const [notificationsEnabled, setNotificationsEnabled] = useState(
     user?.preferences?.notifications || false
   );
-  const [weekStartsOn, setWeekStartsOn] = useState<'sunday' | 'monday'>(
+  const [weekStartsOn, setWeekStartsOn] = useState<'sunday' | 'monday' | 'saturday'>(
     user?.preferences?.displayOptions?.weekStartsOn || 'sunday'
   );
 
@@ -217,11 +217,14 @@ const Settings = () => {
                   <ToggleGroup
                     type="single"
                     value={weekStartsOn}
-                    onValueChange={(value) => value && setWeekStartsOn(value as 'sunday' | 'monday')}
+                    onValueChange={(value) =>
+                      value && setWeekStartsOn(value as 'sunday' | 'monday' | 'saturday')
+                    }
                     className="justify-start"
                   >
                     <ToggleGroupItem value="sunday">Sunday</ToggleGroupItem>
                     <ToggleGroupItem value="monday">Monday</ToggleGroupItem>
+                    <ToggleGroupItem value="saturday">Saturday</ToggleGroupItem>
                   </ToggleGroup>
                 </div>
                 

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -30,7 +30,7 @@ export interface UserPreferences {
   };
   displayOptions: {
     showCents: boolean;
-    weekStartsOn: 'sunday' | 'monday';
+    weekStartsOn: 'sunday' | 'monday' | 'saturday';
     defaultView: 'list' | 'stats' | 'calendar';
     compactMode?: boolean;
     showCategories?: boolean;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -36,7 +36,7 @@ export interface UserPreferences {
   };
   displayOptions: {
     showCents: boolean;
-    weekStartsOn: 'sunday' | 'monday';
+    weekStartsOn: 'sunday' | 'monday' | 'saturday';
     defaultView: 'list' | 'stats' | 'calendar';
     compactMode: boolean;
     showCategories: boolean;

--- a/src/utils/locale/calendar.ts
+++ b/src/utils/locale/calendar.ts
@@ -73,7 +73,7 @@ export const getMonthNames = (
 /**
  * Gets the first day of the week for the current locale
  */
-export const getFirstDayOfWeek = (locale?: SupportedLocale): 0 | 1 => {
+export const getFirstDayOfWeek = (locale?: SupportedLocale): 0 | 1 | 6 => {
   try {
     const settings = getLocaleSettings();
     const localeCode = locale || settings.locale;
@@ -81,12 +81,19 @@ export const getFirstDayOfWeek = (locale?: SupportedLocale): 0 | 1 => {
     // First check user preferences
     const userPreferences = getUserSettings();
     if (userPreferences?.displayOptions?.weekStartsOn) {
-      return userPreferences.displayOptions.weekStartsOn === 'monday' ? 1 : 0;
+      switch (userPreferences.displayOptions.weekStartsOn) {
+        case 'monday':
+          return 1;
+        case 'saturday':
+          return 6;
+        default:
+          return 0;
+      }
     }
     
     // Then check locale settings
     if (settings.firstDayOfWeek !== undefined) {
-      return settings.firstDayOfWeek as 0 | 1;
+      return settings.firstDayOfWeek as 0 | 1 | 6;
     }
     
     // Then check locale defaults

--- a/src/utils/locale/settings.ts
+++ b/src/utils/locale/settings.ts
@@ -38,7 +38,12 @@ export const getLocaleSettings = (): LocaleSettings => {
                 (userPreferences.language && isValidLocale(`${userPreferences.language}-${userPreferences.language.toUpperCase()}`) ? 
                 `${userPreferences.language}-${userPreferences.language.toUpperCase()}` as SupportedLocale : 
                 storedSettings.locale),
-        firstDayOfWeek: userPreferences.displayOptions?.weekStartsOn === 'monday' ? 1 : 0,
+        firstDayOfWeek:
+          userPreferences.displayOptions?.weekStartsOn === 'monday'
+            ? 1
+            : userPreferences.displayOptions?.weekStartsOn === 'saturday'
+            ? 6
+            : 0,
         // If user has date and time format in preferences, use those
         dateFormat: mapDateFormat(userPreferences),
         timeFormat: mapTimeFormat(userPreferences),
@@ -134,7 +139,12 @@ export const updateLocaleSettings = (settings: Partial<LocaleSettings>, syncUser
               showCategories: (displayOptions as any).showCategories === false ? false : true,
               showTags: (displayOptions as any).showTags === false ? false : true,
               // Preserve weekStartsOn from settings.firstDayOfWeek
-              weekStartsOn: settings.firstDayOfWeek === 1 ? 'monday' : 'sunday',
+              weekStartsOn:
+                settings.firstDayOfWeek === 1
+                  ? 'monday'
+                  : settings.firstDayOfWeek === 6
+                  ? 'saturday'
+                  : 'sunday',
               // Handle showCents from settings.numberFormat
               showCents: settings.numberFormat?.minimumFractionDigits !== 0,
               // Map date format


### PR DESCRIPTION
## Summary
- extend `weekStartsOn` union to include `saturday`
- handle Saturday in validation and user context types
- allow choosing Saturday in settings UI
- map Saturday correctly in locale utilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614146aaec83338a0e1c34abebb4bf