### PR TITLE
Add background SMS toggle in settings

### DIFF
--- a/src/context/user/UserContext.tsx
+++ b/src/context/user/UserContext.tsx
@@ -197,7 +197,8 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
             showTags: true
           },
           sms: {
-            autoImport: false
+            autoImport: false,
+            backgroundSmsEnabled: false
           }
         }
       };

--- a/src/context/user/auth-utils.ts
+++ b/src/context/user/auth-utils.ts
@@ -98,7 +98,8 @@ export const getUserFromLocalStorage = (): User | null => {
             showTags: true
           },
           sms: {
-            autoImport: false
+            autoImport: false,
+            backgroundSmsEnabled: false
           }
         };
       }

--- a/src/services/SmsReaderService.ts
+++ b/src/services/SmsReaderService.ts
@@ -54,6 +54,14 @@ export class SmsReaderService {
     }
   }
 
+  static async checkOrRequestPermission(): Promise<boolean> {
+    const hasPermission = await SmsReaderService.hasPermission();
+    if (hasPermission) {
+      return true;
+    }
+    return SmsReaderService.requestPermission();
+  }
+
   static async readSmsMessages(options: SmsReadOptions = {}): Promise<SmsEntry[]> {
     console.log('AIS-01 readSmsMessages', options);
 

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -48,6 +48,7 @@ export interface UserPreferences {
   };
   sms?: {
     autoImport?: boolean;
+    backgroundSmsEnabled?: boolean;
   };
   updatedAt?: string;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -63,6 +63,7 @@ export interface UserPreferences {
     autoDetectProviders: boolean;
     showDetectionNotifications: boolean;
     autoImport?: boolean;
+    backgroundSmsEnabled?: boolean;
   };
   categories?: {
     showUncategorized: boolean;

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -380,7 +380,8 @@ export const getUserSettings = (): UserPreferences => {
       dataRetention: 'forever'
     },
     sms: {
-      autoImport: false
+      autoImport: false,
+      backgroundSmsEnabled: false
     }
   });
 };


### PR DESCRIPTION
## Summary
- implement `checkOrRequestPermission` for SmsReaderService
- add background SMS reading preference and UI toggle
- keep SMS preferences when updating
- update default preference objects

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68614387ef988333bbbfa0b169be5e45