### PR TITLE
Fix settings handlers and event listener cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,9 +60,14 @@ function AppWrapper() {
     };
 
     checkQueue();
-    const resume = CapacitorApp.addListener('resume', checkQueue);
+    let resume: any;
+    CapacitorApp.addListener('resume', checkQueue).then((listener) => {
+      resume = listener;
+    });
     return () => {
-      resume.remove();
+      if (resume) {
+        resume.remove();
+      }
     };
   }, []);
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -129,6 +129,23 @@ const Settings = () => {
       description: t('settings-saved-desc')
     });
   };
+
+  // Legacy handler used by the save button
+  const handleSaveSettings = () => {
+    handleAppearanceSave();
+  };
+
+  // Handler for the display options "save" button
+  const handleDisplayOptionsChange = () => {
+    updateDisplayOptions({
+      weekStartsOn
+    });
+
+    toast({
+      title: t('settings-updated'),
+      description: t('settings-saved-desc')
+    });
+  };
   
   
   return (


### PR DESCRIPTION
## Summary
- define missing handlers in Settings page
- fix App resume listener cleanup to avoid errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861730e5a608333a82cb3e6a91d5c81