### PR TITLE
fix translation loading

### DIFF
--- a/src/context/LocaleContext.tsx
+++ b/src/context/LocaleContext.tsx
@@ -16,16 +16,21 @@ const LocaleContext = createContext<LocaleContextType>({
   t: (key: string) => key,
 });
 
+const translationFiles = import.meta.glob('../locales/*.json', {
+  eager: true,
+  import: 'default'
+}) as Record<string, Translations>;
+
 export const LocaleProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [language, setLanguageState] = useState('en');
   const [translations, setTranslations] = useState<Translations>({});
 
   const loadTranslations = async (lang: string) => {
-    try {
-      const msgs: Translations = (await import(/* @vite-ignore */ `../locales/${lang}.json`)).default;
+    const msgs = translationFiles[`../locales/${lang}.json`];
+    if (msgs) {
       setTranslations(msgs);
-    } catch (err) {
-      console.error('Failed to load translations for', lang, err);
+    } else {
+      console.error(`Translations for ${lang} not found`);
       setTranslations({});
     }
   };


### PR DESCRIPTION
## Summary
- use `import.meta.glob` to map available language files
- load translations eagerly from the glob mapping

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: connect ENETUNREACH 140.82.113.3:443)*

------
https://chatgpt.com/codex/tasks/task_e_68617dfa13f08333b1931974f6560216