### PR TITLE
Fix object syntax in ReviewSmsTransactions

### DIFF
--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -101,10 +101,8 @@ const ReviewSmsTransactions: React.FC = () => {
 
             title: generateDefaultTitle({ ...txn, category: cat, subcategory: sub }),
             sender: msg.sender,
-            alwaysApply: false
+            alwaysApply: false,
 
-
-           
             confidence,
             fieldConfidences,
             parsingStatus


### PR DESCRIPTION
## Summary
- fix syntax in `ReviewSmsTransactions` by adding missing comma

## Testing
- `npm run test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618f40a82c833392f32f1196b33022