### PR TITLE
Update env vars for Supabase

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,10 @@
+# Example environment configuration
+# Required for Supabase integration
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# Firebase functions base URL
+# VITE_CLOUD_FUNCTIONS_BASE_URL=https://us-central1-xpensia-505ac.cloudfunctions.net
+
+# Optional: default number of months of SMS history to scan
+# VITE_SMS_LOOKBACK_MONTHS=6

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Simply open [Lovable](https://lovable.dev/projects/44f11ecc-0e77-4a7d-a302-6102d
 The app reads configuration from Vite environment variables. The newly added `VITE_CLOUD_FUNCTIONS_BASE_URL` controls where the Firebase Cloud Functions requests are sent.
 `VITE_SMS_LOOKBACK_MONTHS` sets the default number of months of SMS history to scan when importing messages (default `6`).
 
+Two variables are required to connect to Supabase:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+
+Create a `.env` file based on `.env.sample` and set these values before running the app.
+
+For the Cloud Functions base URL you can use:
+
 - **Production URL:** `https://us-central1-xpensia-505ac.cloudfunctions.net`
 - **Local emulator URL:** `http://localhost:5001/xpensia-505ac/us-central1`
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -28,8 +28,8 @@ declare global {
 }
 
 // Supabase configuration
-export const SUPABASE_URL = getEnvironmentVariable('SUPABASE_URL', 'https://cfacrxykzimdfzvbwhba.supabase.co');
-export const SUPABASE_ANON_KEY = getEnvironmentVariable('SUPABASE_ANON_KEY', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNmYWNyeHlremltZGZ6dmJ3aGJhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDMyNDkxMzQsImV4cCI6MjA1ODgyNTEzNH0.x_ZGHodH9IYx5cgKRinAWQ2WpPX9iJaC32GfSKP0noY');
+export const SUPABASE_URL = getEnvironmentVariable('SUPABASE_URL');
+export const SUPABASE_ANON_KEY = getEnvironmentVariable('SUPABASE_ANON_KEY');
 
 // Feature flags
 export const ENABLE_SUPABASE_AUTH = getEnvironmentVariable('ENABLE_SUPABASE_AUTH', 'false') === 'true';


### PR DESCRIPTION
## Summary
- remove defaults for Supabase URL and key
- provide `.env.sample` for required env vars
- document setting Supabase variables in README

## Testing
- `npm test --silent` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a01a15288333a6e11ce29c7366d2