### PR TITLE
Update plugin compile SDK versions

### DIFF
--- a/capacitor-background-sms-listener/android/build.gradle
+++ b/capacitor-background-sms-listener/android/build.gradle
@@ -4,7 +4,8 @@ plugins {
 
 android {
     namespace 'app.xpensia.com.plugins.backgroundsmslistener'
-    compileSdkVersion 34
+    // Align with project-wide compile SDK
+    compileSdkVersion 35
 
     defaultConfig {
         minSdkVersion 22

--- a/capacitor-sms-reader/android/build.gradle
+++ b/capacitor-sms-reader/android/build.gradle
@@ -4,7 +4,8 @@ plugins {
 
 android {
     namespace 'app.xpensia.com.plugins.smsreader'
-    compileSdkVersion 34
+    // Align with project-wide compile SDK
+    compileSdkVersion 35
 
     defaultConfig {
         minSdkVersion 23    


### PR DESCRIPTION
## Summary
- bump plugin compileSdkVersion to 35

## Testing
- `./gradlew build --console=plain` *(fails: Could not read script 'android/capacitor-cordova-android-plugins/cordova.variables.gradle' as it does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6861a246201c8333a5dbef11e4c94ee2