### PR TITLE
Implement basic Budget module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,10 @@ import ReviewSmsTransactions from '@/pages/ReviewSmsTransactions';
 import Analytics from './pages/Analytics';
 import Settings from './pages/Settings';
 import NotFound from './pages/NotFound';
+import AccountsPage from './pages/budget/AccountsPage';
+import SetBudgetPage from './pages/budget/SetBudgetPage';
+import BudgetReportPage from './pages/budget/BudgetReportPage';
+import BudgetInsightsPage from './pages/budget/BudgetInsightsPage';
 
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { Capacitor } from '@capacitor/core';
@@ -233,6 +237,10 @@ function AppWrapper() {
       <Route path="/sms/vendors" element={<VendorCategorization />} />
       <Route path="/vendor-mapping" element={<VendorMapping />} />
       <Route path="/review-sms-transactions" element={<ReviewSmsTransactions />} />
+      <Route path="/budget/accounts" element={<AccountsPage />} />
+      <Route path="/budget/set" element={<SetBudgetPage />} />
+      <Route path="/budget/report" element={<BudgetReportPage />} />
+      <Route path="/budget/insights" element={<BudgetInsightsPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
     <SmartPasteReviewQueueModal

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,7 +25,14 @@ const Sidebar: React.FC = () => {
     { name: 'Settings', path: '/settings', icon: <Settings size={20} /> },
 	{ name: 'Keyword Bank', path: '/keyword-bank', icon: <Tag size={20} /> },
     { name: 'Build Template', path: '/build-template', icon: <BrainCircuit size={20} /> }
-	
+
+  ];
+
+  const budgetItems = [
+    { name: 'Accounts & Balances', path: '/budget/accounts' },
+    { name: 'Set Budget', path: '/budget/set' },
+    { name: 'Budget vs Actual', path: '/budget/report' },
+    { name: 'Suggestions & Insights', path: '/budget/insights' }
   ];
 
   const isActive = (path: string) => {
@@ -39,23 +46,42 @@ const Sidebar: React.FC = () => {
           <h2 className="text-xl font-bold">Xpensia</h2>
         </div>
         
-        <nav className="flex-1 px-3 py-2">
+        <nav className="flex-1 px-3 py-2 overflow-y-auto">
           <ul className="space-y-1">
-            {navItems.map((item) => (
-              <li key={item.path}>
-                <Link
-                  to={item.path}
-                  className={`flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                    isActive(item.path)
-                      ? 'bg-primary text-primary-foreground'
-                      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                  }`}
-                >
-                  <span className="mr-3">{item.icon}</span>
-                  {item.name}
-                </Link>
-              </li>
-            ))}
+          {navItems.map((item) => (
+            <li key={item.path}>
+              <Link
+                to={item.path}
+                className={`flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  isActive(item.path)
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                }`}
+              >
+                <span className="mr-3">{item.icon}</span>
+                {item.name}
+              </Link>
+            </li>
+          ))}
+            <li>
+              <details open>
+                <summary className="flex items-center px-3 py-2 rounded-md text-sm font-medium cursor-pointer select-none">
+                  Budget ▾
+                </summary>
+                <ul className="mt-1 ml-4 space-y-1">
+                  {budgetItems.map(b => (
+                    <li key={b.path}>
+                      <Link
+                        to={b.path}
+                        className={`block px-3 py-1 rounded-md text-sm transition-colors ${isActive(b.path) ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                      >
+                        {b.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            </li>
           </ul>
         </nav>
         

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,0 +1,9 @@
+export interface Account {
+  id: string;
+  name: string;
+  type: 'Bank' | 'Cash' | 'Crypto' | 'Gold' | 'Stocks' | 'Sukuk' | 'Real Estate' | 'Loan';
+  currency: string;
+  initialBalance: number;
+  startDate: string;
+  tags?: string[];
+}

--- a/src/models/budget.ts
+++ b/src/models/budget.ts
@@ -1,0 +1,12 @@
+export interface Budget {
+  id: string;
+  scope: 'account' | 'category' | 'subcategory';
+  targetId: string;
+  amount: number;
+  currency: string;
+  period: 'weekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
+  startDate: string;
+  endDate?: string;
+  rollover?: boolean;
+  notes?: string;
+}

--- a/src/pages/budget/AccountsPage.tsx
+++ b/src/pages/budget/AccountsPage.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import Layout from '@/components/Layout';
+import PageHeader from '@/components/layout/PageHeader';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { DatePicker } from '@/components/ui/date-picker';
+import { formatCurrency } from '@/utils/format-utils';
+import { v4 as uuidv4 } from 'uuid';
+import { accountService } from '@/services/AccountService';
+import { Account } from '@/models/account';
+import { CURRENCIES } from '@/lib/categories-data';
+
+const TYPES: Account['type'][] = ['Bank','Cash','Crypto','Gold','Stocks','Sukuk','Real Estate','Loan'];
+
+const AccountsPage = () => {
+  const [accounts, setAccounts] = React.useState<Account[]>(() => accountService.getAccounts());
+  const [open, setOpen] = React.useState(false);
+  const today = React.useMemo(() => new Date().toISOString().split('T')[0], []);
+  const [form, setForm] = React.useState<Omit<Account,'id'>>({
+    name: '',
+    type: 'Bank',
+    currency: 'USD',
+    initialBalance: 0,
+    startDate: today,
+    tags: []
+  });
+
+  const handleSave = () => {
+    const newAccount: Account = { id: uuidv4(), ...form };
+    accountService.addAccount(newAccount);
+    setAccounts(accountService.getAccounts());
+    setOpen(false);
+    setForm({ ...form, name: '', initialBalance: 0 });
+  };
+
+  return (
+    <Layout showBack>
+      <div className="container px-1">
+        <PageHeader title="Accounts & Balances" />
+        <div className="space-y-3 py-4">
+          {accounts.map(acc => (
+            <div key={acc.id} className="flex items-center justify-between bg-card p-3 rounded-xl">
+              <span>{acc.name}</span>
+              <span>{formatCurrency(acc.initialBalance, acc.currency)}</span>
+            </div>
+          ))}
+          <Button onClick={() => setOpen(true)}>Add Account</Button>
+        </div>
+      </div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Account</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input placeholder="Name" value={form.name} onChange={e=>setForm({...form,name:e.target.value})} />
+            <Select value={form.type} onValueChange={val=>setForm({...form,type:val as Account['type']})}>
+              <SelectTrigger><SelectValue placeholder="Type" /></SelectTrigger>
+              <SelectContent>
+                {TYPES.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <Select value={form.currency} onValueChange={val=>setForm({...form,currency:val})}>
+              <SelectTrigger><SelectValue placeholder="Currency" /></SelectTrigger>
+              <SelectContent>
+                {CURRENCIES.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <Input type="number" placeholder="Initial Balance" value={form.initialBalance} onChange={e=>setForm({...form,initialBalance:parseFloat(e.target.value)||0})}/>
+            <DatePicker date={new Date(form.startDate)} setDate={d=>setForm({...form,startDate:d?d.toISOString().split('T')[0]:form.startDate})} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={handleSave}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Layout>
+  );
+};
+
+export default AccountsPage;

--- a/src/pages/budget/BudgetInsightsPage.tsx
+++ b/src/pages/budget/BudgetInsightsPage.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Layout from '@/components/Layout';
+import PageHeader from '@/components/layout/PageHeader';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useTransactions } from '@/context/TransactionContext';
+import { budgetService } from '@/services/BudgetService';
+import { accountService } from '@/services/AccountService';
+import { transactionService } from '@/services/TransactionService';
+import { Budget } from '@/models/budget';
+
+const BudgetInsightsPage = () => {
+  const { transactions } = useTransactions();
+  const budgets = React.useMemo(() => budgetService.getBudgets(), []);
+  const accounts = React.useMemo(() => accountService.getAccounts(), []);
+  const categories = React.useMemo(() => transactionService.getCategories(), []);
+
+  const getTargetName = (b: Budget) => {
+    const all = [...accounts, ...categories];
+    const t = all.find((a: any) => a.id === b.targetId);
+    return t ? (t as any).name : b.targetId;
+  };
+
+  const insights: { id: string; text: string }[] = [];
+
+  budgets.forEach(b => {
+    const spent = transactions
+      .filter(t => (b.scope === 'account' ? t.fromAccount === getTargetName(b) : t.category === getTargetName(b)))
+      .reduce((s, t) => s + Math.abs(t.amount), 0);
+    if (spent > b.amount) {
+      insights.push({ id: b.id + 'over', text: `Over budget for ${getTargetName(b)}` });
+    } else if (spent < b.amount * 0.1) {
+      insights.push({ id: b.id + 'under', text: `${getTargetName(b)} under 10% of budget` });
+    }
+  });
+
+  if (!insights.length) {
+    insights.push({ id: 'none', text: 'No insights available yet.' });
+  }
+
+  return (
+    <Layout showBack>
+      <div className="container px-1 space-y-3">
+        <PageHeader title="Suggestions & Insights" />
+        {insights.map(i => (
+          <Alert key={i.id} className="bg-card">
+            <AlertTitle>Insight</AlertTitle>
+            <AlertDescription>{i.text}</AlertDescription>
+          </Alert>
+        ))}
+      </div>
+    </Layout>
+  );
+};
+
+export default BudgetInsightsPage;

--- a/src/pages/budget/BudgetReportPage.tsx
+++ b/src/pages/budget/BudgetReportPage.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import Layout from '@/components/Layout';
+import PageHeader from '@/components/layout/PageHeader';
+import { useTransactions } from '@/context/TransactionContext';
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, LineChart, Line, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
+import { budgetService } from '@/services/BudgetService';
+import { accountService } from '@/services/AccountService';
+import { transactionService } from '@/services/TransactionService';
+import { Budget } from '@/models/budget';
+import { formatCurrency } from '@/utils/format-utils';
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
+
+const BudgetReportPage = () => {
+  const { transactions } = useTransactions();
+  const budgets = React.useMemo(() => budgetService.getBudgets(), []);
+  const accounts = React.useMemo(() => accountService.getAccounts(), []);
+  const categories = React.useMemo(() => transactionService.getCategories(), []);
+
+  const getTargetName = (b: Budget) => {
+    const all = [...accounts, ...categories];
+    const t = all.find((a: any) => a.id === b.targetId);
+    return t ? (t as any).name : b.targetId;
+  };
+
+  const totalBudget = budgets.reduce((sum, b) => sum + b.amount, 0);
+  const totalSpent = transactions.filter(t => t.amount < 0).reduce((s, t) => s + Math.abs(t.amount), 0);
+  const pieData = [
+    { name: 'Budgeted', value: totalBudget },
+    { name: 'Spent', value: totalSpent }
+  ];
+
+  const overBudget = budgets.map(b => {
+    const spent = transactions
+      .filter(t => (b.scope === 'account' ? t.fromAccount === getTargetName(b) : t.category === getTargetName(b)))
+      .reduce((s, t) => s + Math.abs(t.amount), 0);
+    return { name: getTargetName(b), value: Math.max(0, spent - b.amount) };
+  }).filter(d => d.value > 0);
+
+  const trendData = budgets.map(b => {
+    const spent = transactions
+      .filter(t => t.category === getTargetName(b))
+      .reduce((s, t) => s + Math.abs(t.amount), 0);
+    return { name: getTargetName(b), budget: b.amount, spent };
+  });
+
+  return (
+    <Layout showBack>
+      <div className="container px-1 space-y-4">
+        <PageHeader title="Budget vs Actual" />
+        <div className="bg-card p-4 rounded-xl">
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={pieData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
+                  {pieData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+                </Pie>
+                <Tooltip formatter={(v:number)=>formatCurrency(v)} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+        <div className="bg-card p-4 rounded-xl">
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={overBudget} margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
+                <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                <YAxis tickFormatter={v=>v.toString()} />
+                <Bar dataKey="value" fill="#ff4d4f" />
+                <Tooltip formatter={(v:number)=>formatCurrency(v)} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+        <div className="bg-card p-4 rounded-xl">
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={trendData} margin={{ top: 10, right: 20, left: 0, bottom: 20 }}>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                <YAxis tickFormatter={v=>v.toString()} />
+                <Tooltip formatter={(v:number)=>formatCurrency(v)} />
+                <Line type="monotone" dataKey="budget" stroke="#8884d8" />
+                <Line type="monotone" dataKey="spent" stroke="#82ca9d" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default BudgetReportPage;

--- a/src/pages/budget/SetBudgetPage.tsx
+++ b/src/pages/budget/SetBudgetPage.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import Layout from '@/components/Layout';
+import PageHeader from '@/components/layout/PageHeader';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
+import { DatePicker } from '@/components/ui/date-picker';
+import { formatCurrency } from '@/utils/format-utils';
+import { v4 as uuidv4 } from 'uuid';
+import { budgetService } from '@/services/BudgetService';
+import { accountService } from '@/services/AccountService';
+import { Budget } from '@/models/budget';
+import { Account } from '@/models/account';
+import { transactionService } from '@/services/TransactionService';
+import { CURRENCIES } from '@/lib/categories-data';
+
+const periods = ['weekly','monthly','quarterly','yearly','custom'];
+
+const SetBudgetPage = () => {
+  const [budgets, setBudgets] = React.useState<Budget[]>(() => budgetService.getBudgets());
+  const [open, setOpen] = React.useState(false);
+  const [scope, setScope] = React.useState<Budget['scope']>('account');
+  const [form, setForm] = React.useState<Omit<Budget,'id'>>({
+    scope: 'account',
+    targetId: '',
+    amount: 0,
+    currency: 'USD',
+    period: 'monthly',
+    startDate: new Date().toISOString().split('T')[0],
+    rollover: false,
+    notes: ''
+  });
+
+  const accounts = React.useMemo(() => accountService.getAccounts(), []);
+  const categories = React.useMemo(() => transactionService.getCategories(), []);
+  const subcats = React.useMemo(() => categories.filter(c => c.parentId), [categories]);
+
+  const targets = scope === 'account'
+    ? accounts.map(a => ({ id: a.id, name: a.name }))
+    : scope === 'category'
+      ? categories.filter(c => !c.parentId).map(c => ({ id: c.id, name: c.name }))
+      : subcats.map(c => ({ id: c.id, name: c.name }));
+
+  const handleSave = () => {
+    if (!form.targetId) return;
+    const newBudget: Budget = { id: uuidv4(), ...form };
+    budgetService.addBudget(newBudget);
+    setBudgets(budgetService.getBudgets());
+    setOpen(false);
+    setForm({ ...form, targetId: '', amount: 0, notes: '' });
+  };
+
+  const displayTarget = (b: Budget) => {
+    const all = [...accounts, ...categories, ...subcats] as any[];
+    const t = all.find(x => x.id === b.targetId);
+    return t ? t.name : b.targetId;
+  };
+
+  return (
+    <Layout showBack>
+      <div className="container px-1">
+        <PageHeader title="Set Budget" />
+        <div className="space-y-3 py-4">
+          {budgets.map(b => (
+            <div key={b.id} className="flex items-center justify-between bg-card p-3 rounded-xl">
+              <span>{displayTarget(b)}</span>
+              <span>{formatCurrency(b.amount, b.currency)}</span>
+            </div>
+          ))}
+          <Button onClick={() => setOpen(true)}>Add Budget</Button>
+        </div>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Budget</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Select value={scope} onValueChange={val => { setScope(val as Budget['scope']); setForm({ ...form, scope: val as Budget['scope'], targetId: '' }); }}>
+              <SelectTrigger><SelectValue placeholder="Scope" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="account">Account</SelectItem>
+                <SelectItem value="category">Category</SelectItem>
+                <SelectItem value="subcategory">Subcategory</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={form.targetId} onValueChange={val => setForm({ ...form, targetId: val })}>
+              <SelectTrigger><SelectValue placeholder="Target" /></SelectTrigger>
+              <SelectContent>
+                {targets.map(t => <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <Input type="number" placeholder="Amount" value={form.amount} onChange={e=>setForm({...form,amount:parseFloat(e.target.value)||0})} />
+            <Select value={form.currency} onValueChange={val => setForm({ ...form, currency: val })}>
+              <SelectTrigger><SelectValue placeholder="Currency" /></SelectTrigger>
+              <SelectContent>
+                {CURRENCIES.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <Select value={form.period} onValueChange={val => setForm({ ...form, period: val as Budget['period'] })}>
+              <SelectTrigger><SelectValue placeholder="Period" /></SelectTrigger>
+              <SelectContent>
+                {periods.map(p => <SelectItem key={p} value={p}>{p.charAt(0).toUpperCase()+p.slice(1)}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <div className="flex items-center space-x-2">
+              <Checkbox id="roll" checked={form.rollover} onCheckedChange={v=>setForm({...form,rollover:!!v})} />
+              <label htmlFor="roll" className="text-sm">Rollover</label>
+            </div>
+            <Textarea placeholder="Notes" value={form.notes} onChange={e=>setForm({...form,notes:e.target.value})} />
+            <DatePicker date={new Date(form.startDate)} setDate={d=>setForm({...form,startDate:d?d.toISOString().split('T')[0]:form.startDate})} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={handleSave}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Layout>
+  );
+};
+
+export default SetBudgetPage;

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -1,0 +1,39 @@
+import { v4 as uuidv4 } from 'uuid';
+import { Account } from '@/models/account';
+
+const STORAGE_KEY = 'xpensia_accounts';
+
+export class AccountService {
+  getAccounts(): Account[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const arr: Partial<Account>[] = raw ? JSON.parse(raw) : [];
+      return arr.map(a => ({
+        id: a.id || uuidv4(),
+        name: a.name || '',
+        type: (a.type as Account['type']) || 'Cash',
+        currency: a.currency || 'USD',
+        initialBalance: a.initialBalance || 0,
+        startDate: a.startDate || new Date().toISOString().split('T')[0],
+        tags: a.tags || []
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  addAccount(account: Account) {
+    const accounts = this.getAccounts();
+    accounts.push(account);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts));
+  }
+
+  updateAccount(id: string, updates: Partial<Account>) {
+    const accounts = this.getAccounts().map(a =>
+      a.id === id ? { ...a, ...updates } : a
+    );
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts));
+  }
+}
+
+export const accountService = new AccountService();

--- a/src/services/BudgetService.ts
+++ b/src/services/BudgetService.ts
@@ -1,0 +1,28 @@
+import { v4 as uuidv4 } from 'uuid';
+import { Budget } from '@/models/budget';
+
+const STORAGE_KEY = 'xpensia_budgets';
+
+export class BudgetService {
+  getBudgets(): Budget[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) as Budget[] : [];
+    } catch {
+      return [];
+    }
+  }
+
+  addBudget(budget: Budget) {
+    const budgets = this.getBudgets();
+    budgets.push(budget);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(budgets));
+  }
+
+  getBudgetSummary(period: string) {
+    const budgets = this.getBudgets();
+    return budgets.filter(b => b.period === period);
+  }
+}
+
+export const budgetService = new BudgetService();


### PR DESCRIPTION
## Summary
- add `Account` and `Budget` models
- create `AccountService` and `BudgetService` for local storage
- implement pages for Accounts, Set Budget, Budget Report and Budget Insights
- route new pages in `App`
- show Budget section in sidebar
- make sidebar scrollable

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68641497d10483339107141f060c052b