### PR TITLE
Switch Budget icon to Scale

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Upload,
   BrainCircuit,
   Tag,
-  PieChart,
+  Scale,
   CreditCard,
   ClipboardList,
   Target,
@@ -83,7 +83,7 @@ const Sidebar: React.FC = () => {
                     : 'text-muted-foreground hover:bg-muted hover:text-foreground'
                 }`}
               >
-                <PieChart size={20} className="mr-3" />
+                <Scale size={20} className="mr-3" />
                 <span className="flex-1 text-left">Budget</span>
                 <span className="ml-auto">{budgetOpen ? '▾' : '▸'}</span>
               </button>

--- a/src/components/header/MainNavigation.tsx
+++ b/src/components/header/MainNavigation.tsx
@@ -5,9 +5,10 @@ import { motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { getNavItems } from './route-constants';
 import { 
-  Home, 
-  PieChart, 
-  ListIcon, 
+  Home,
+  PieChart,
+  Scale,
+  ListIcon,
   MessageSquare, 
   Settings, 
   User, 
@@ -19,6 +20,7 @@ import {
 const iconMap = {
   'Home': Home,
   'PieChart': PieChart,
+  'Scale': Scale,
   'List': ListIcon,
   'MessageSquare': MessageSquare,
   'Settings': Settings,

--- a/src/components/header/MobileNavigation.tsx
+++ b/src/components/header/MobileNavigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { LogOut, Menu, Home, PieChart, List, MessageSquare, Settings, User, Upload, BrainCircuit } from 'lucide-react';
+import { LogOut, Menu, Home, PieChart, Scale, List, MessageSquare, Settings, User, Upload, BrainCircuit } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -19,6 +19,7 @@ import { getNavItems } from './route-constants';
 const iconMap = {
   'Home': Home,
   'PieChart': PieChart,
+  'Scale': Scale,
   'List': List,
   'MessageSquare': MessageSquare,
   'Settings': Settings,

--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -43,7 +43,7 @@ export const getNavItems = () => [
   {
     title: 'Budget',
     path: '/budget/accounts',
-    icon: 'PieChart',
+    icon: 'Scale',
     description: 'Manage budgets and accounts'
   },
   {


### PR DESCRIPTION
## Summary
- update Sidebar to use `<Scale>` instead of `<PieChart>`
- adjust navigation route and icon maps for new `Scale` icon

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6864248155dc83339ddd290f0c286b05