### PR TITLE
Fix Sidebar budget auto-expand

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -38,6 +38,10 @@ const Sidebar: React.FC = () => {
     location.pathname.startsWith('/budget')
   );
 
+  React.useEffect(() => {
+    setBudgetOpen(location.pathname.startsWith('/budget'));
+  }, [location.pathname]);
+
   const budgetItems = [
     { name: 'Accounts', path: '/budget/accounts', icon: <CreditCard size={18} /> },
     { name: 'Budgets', path: '/budget/set', icon: <ClipboardList size={18} /> },


### PR DESCRIPTION
## Summary
- auto expand Budget submenu on route change

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686425a701e883338bbaef9b964553ed