### PR TITLE
Add budget dialog navigation

### DIFF
--- a/src/components/header/MainNavigation.tsx
+++ b/src/components/header/MainNavigation.tsx
@@ -1,38 +1,65 @@
-
-import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import { motion } from 'framer-motion';
-import { cn } from '@/lib/utils';
-import { getNavItems } from './route-constants';
-import { 
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+import { getNavItems } from "./route-constants";
+import {
   Home,
   PieChart,
   Scale,
   ListIcon,
-  MessageSquare, 
-  Settings, 
-  User, 
-  Upload, 
-  BrainCircuit 
-} from 'lucide-react';
+  MessageSquare,
+  Settings,
+  User,
+  Upload,
+  BrainCircuit,
+  CreditCard,
+  ClipboardList,
+  Target,
+  TrendingDown,
+} from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
 // Map of icon names to their components
 const iconMap = {
-  'Home': Home,
-  'PieChart': PieChart,
-  'Scale': Scale,
-  'List': ListIcon,
-  'MessageSquare': MessageSquare,
-  'Settings': Settings,
-  'User': User,
-  'Upload': Upload,
-  'BrainCircuit': BrainCircuit
+  Home: Home,
+  PieChart: PieChart,
+  Scale: Scale,
+  List: ListIcon,
+  MessageSquare: MessageSquare,
+  Settings: Settings,
+  User: User,
+  Upload: Upload,
+  BrainCircuit: BrainCircuit,
 };
 
 export const MainNavigation: React.FC = () => {
   const location = useLocation();
   const navItems = getNavItems();
-  
+  const [budgetOpen, setBudgetOpen] = React.useState(false);
+
+  const budgetItems = [
+    {
+      name: "Accounts",
+      path: "/budget/accounts",
+      icon: <CreditCard size={18} />,
+    },
+    { name: "Budgets", path: "/budget/set", icon: <ClipboardList size={18} /> },
+    { name: "Reports", path: "/budget/report", icon: <Target size={18} /> },
+    {
+      name: "Insights",
+      path: "/budget/insights",
+      icon: <TrendingDown size={18} />,
+    },
+  ];
+
   return (
     <motion.nav
       initial={{ opacity: 0, y: -10 }}
@@ -44,19 +71,71 @@ export const MainNavigation: React.FC = () => {
         {navItems.map((item) => {
           // Get the icon component from our icon map
           const IconComponent = iconMap[item.icon as keyof typeof iconMap];
-          
+
+          if (item.modal === "budget") {
+            return (
+              <li key={item.title}>
+                <button
+                  type="button"
+                  onClick={() => setBudgetOpen(true)}
+                  className={cn(
+                    "flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                    location.pathname.startsWith("/budget")
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                  )}
+                  title={item.title}
+                >
+                  {IconComponent && (
+                    <IconComponent size={18} className="mr-2" />
+                  )}
+                  {item.title}
+                </button>
+
+                <Dialog open={budgetOpen} onOpenChange={setBudgetOpen}>
+                  <DialogContent className="sm:max-w-xs">
+                    <DialogHeader>
+                      <DialogTitle>Select Budget Page</DialogTitle>
+                    </DialogHeader>
+                    <div className="grid gap-2 py-2">
+                      {budgetItems.map((b) => (
+                        <DialogClose asChild key={b.path}>
+                          <Button
+                            asChild
+                            variant="outline"
+                            className="justify-start"
+                          >
+                            <Link
+                              to={b.path}
+                              className="flex items-center gap-2"
+                            >
+                              {b.icon}
+                              {b.name}
+                            </Link>
+                          </Button>
+                        </DialogClose>
+                      ))}
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              </li>
+            );
+          }
+
           return (
             <li key={item.title}>
-              <Link 
-                to={item.path} 
+              <Link
+                to={item.path ?? ""}
                 className={cn(
                   "flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                  location.pathname === item.path 
-                    ? "bg-primary/10 text-primary" 
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent"
+                  location.pathname === item.path
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
                 )}
                 title={item.title}
-                aria-current={location.pathname === item.path ? "page" : undefined}
+                aria-current={
+                  location.pathname === item.path ? "page" : undefined
+                }
               >
                 {IconComponent && <IconComponent size={18} className="mr-2" />}
                 {item.title}

--- a/src/components/header/MobileNavigation.tsx
+++ b/src/components/header/MobileNavigation.tsx
@@ -1,9 +1,25 @@
-import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import { LogOut, Menu, Home, PieChart, Scale, List, MessageSquare, Settings, User, Upload, BrainCircuit } from 'lucide-react';
-import { useUser } from '@/context/UserContext';
-import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import {
+  LogOut,
+  Menu,
+  Home,
+  PieChart,
+  Scale,
+  List,
+  MessageSquare,
+  Settings,
+  User,
+  Upload,
+  BrainCircuit,
+  CreditCard,
+  ClipboardList,
+  Target,
+  TrendingDown,
+} from "lucide-react";
+import { useUser } from "@/context/UserContext";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Sheet,
   SheetContent,
@@ -11,32 +27,57 @@ import {
   SheetTitle,
   SheetTrigger,
   SheetClose,
-} from '@/components/ui/sheet';
-import { cn } from '@/lib/utils';
-import { getNavItems } from './route-constants';
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { getNavItems } from "./route-constants";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
 
 // Map of icon names to their components
 const iconMap = {
-  'Home': Home,
-  'PieChart': PieChart,
-  'Scale': Scale,
-  'List': List,
-  'MessageSquare': MessageSquare,
-  'Settings': Settings,
-  'User': User,
-  'Upload': Upload,
-  'BrainCircuit': BrainCircuit
+  Home: Home,
+  PieChart: PieChart,
+  Scale: Scale,
+  List: List,
+  MessageSquare: MessageSquare,
+  Settings: Settings,
+  User: User,
+  Upload: Upload,
+  BrainCircuit: BrainCircuit,
 };
 
 interface MobileNavigationProps {
   currentPageTitle: string;
 }
 
-export const MobileNavigation: React.FC<MobileNavigationProps> = ({ currentPageTitle }) => {
+export const MobileNavigation: React.FC<MobileNavigationProps> = ({
+  currentPageTitle,
+}) => {
   const location = useLocation();
   const { user, logOut } = useUser();
   const navItems = getNavItems();
-  
+  const [budgetOpen, setBudgetOpen] = React.useState(false);
+
+  const budgetItems = [
+    {
+      name: "Accounts",
+      path: "/budget/accounts",
+      icon: <CreditCard size={18} />,
+    },
+    { name: "Budgets", path: "/budget/set", icon: <ClipboardList size={18} /> },
+    { name: "Reports", path: "/budget/report", icon: <Target size={18} /> },
+    {
+      name: "Insights",
+      path: "/budget/insights",
+      icon: <TrendingDown size={18} />,
+    },
+  ];
+
   return (
     <div className="md:hidden">
       <Sheet>
@@ -49,68 +90,135 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({ currentPageT
           <SheetHeader className="border-b pb-4 mb-4">
             <SheetTitle className="flex items-center">
               <div className="h-8 w-8 rounded-lg bg-primary overflow-hidden flex items-center justify-center mr-2">
-                <img 
-                  src="/xpensia-logo.png" 
-                  alt="Xpensia Logo" 
+                <img
+                  src="/xpensia-logo.png"
+                  alt="Xpensia Logo"
                   className="w-full h-full object-cover"
                 />
               </div>
               <span>{currentPageTitle}</span>
             </SheetTitle>
           </SheetHeader>
-          
+
           <div className="py-2">
             {user && (
               <div className="flex items-center space-x-3 p-4 mb-4 bg-muted/50 rounded-lg">
                 <Avatar>
                   <AvatarImage
-                    src={user.avatar || '/placeholder.svg'}
-                    alt={user.fullName || 'User'}
+                    src={user.avatar || "/placeholder.svg"}
+                    alt={user.fullName || "User"}
                   />
                   <AvatarFallback>
-                    {user.fullName ? user.fullName.charAt(0) : 'U'}
+                    {user.fullName ? user.fullName.charAt(0) : "U"}
                   </AvatarFallback>
                 </Avatar>
                 <div>
-                  <p className="text-sm font-medium">{user.fullName || 'User'}</p>
-                  <p className="text-xs text-muted-foreground">{user.email || user.phone || 'No contact info'}</p>
+                  <p className="text-sm font-medium">
+                    {user.fullName || "User"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {user.email || user.phone || "No contact info"}
+                  </p>
                 </div>
               </div>
             )}
-            
+
             <nav className="space-y-1">
               {navItems.map((item) => {
                 // Get the icon component from our icon map
-                const IconComponent = iconMap[item.icon as keyof typeof iconMap];
-                
+                const IconComponent =
+                  iconMap[item.icon as keyof typeof iconMap];
+
+                if (item.modal === "budget") {
+                  return (
+                    <div key={item.title}>
+                      <button
+                        type="button"
+                        onClick={() => setBudgetOpen(true)}
+                        className={cn(
+                          "flex w-full items-center px-4 py-3 rounded-md transition-colors",
+                          location.pathname.startsWith("/budget")
+                            ? "bg-primary/10 text-primary"
+                            : "text-foreground hover:bg-accent",
+                        )}
+                      >
+                        {IconComponent && (
+                          <IconComponent size={20} className="mr-3" />
+                        )}
+                        <div className="flex-1 text-left">
+                          <p className="font-medium">{item.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {item.description}
+                          </p>
+                        </div>
+                      </button>
+
+                      <Dialog open={budgetOpen} onOpenChange={setBudgetOpen}>
+                        <DialogContent className="sm:max-w-xs">
+                          <DialogHeader>
+                            <DialogTitle>Select Budget Page</DialogTitle>
+                          </DialogHeader>
+                          <div className="grid gap-2 py-2">
+                            {budgetItems.map((b) => (
+                              <DialogClose asChild key={b.path}>
+                                <SheetClose asChild>
+                                  <Button
+                                    asChild
+                                    variant="outline"
+                                    className="justify-start"
+                                  >
+                                    <Link
+                                      to={b.path}
+                                      className="flex items-center gap-2"
+                                    >
+                                      {b.icon}
+                                      {b.name}
+                                    </Link>
+                                  </Button>
+                                </SheetClose>
+                              </DialogClose>
+                            ))}
+                          </div>
+                        </DialogContent>
+                      </Dialog>
+                    </div>
+                  );
+                }
+
                 return (
                   <SheetClose asChild key={item.title}>
-                    <Link 
-                      to={item.path} 
+                    <Link
+                      to={item.path}
                       className={cn(
                         "flex items-center px-4 py-3 rounded-md hover:bg-accent transition-colors",
-                        location.pathname === item.path 
-                          ? "bg-primary/10 text-primary" 
-                          : "text-foreground"
+                        location.pathname === item.path
+                          ? "bg-primary/10 text-primary"
+                          : "text-foreground",
                       )}
-                      aria-current={location.pathname === item.path ? "page" : undefined}
+                      aria-current={
+                        location.pathname === item.path ? "page" : undefined
+                      }
                     >
-                      {IconComponent && <IconComponent size={20} className="mr-3" />}
+                      {IconComponent && (
+                        <IconComponent size={20} className="mr-3" />
+                      )}
                       <div>
                         <p className="font-medium">{item.title}</p>
-                        <p className="text-xs text-muted-foreground">{item.description}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {item.description}
+                        </p>
                       </div>
                     </Link>
                   </SheetClose>
                 );
               })}
             </nav>
-            
+
             {user && (
               <div className="mt-8 pt-4 border-t">
-                <Button 
-                  variant="destructive" 
-                  className="w-full justify-start" 
+                <Button
+                  variant="destructive"
+                  className="w-full justify-start"
                   onClick={logOut}
                 >
                   <LogOut size={18} className="mr-2" />

--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -1,79 +1,79 @@
-
 // Map routes to their corresponding titles
 export const routeTitleMap: Record<string, string> = {
-  '/': 'Xpensia',
-  '/home': 'Xpensia',
-  '/transactions': 'Transactions',
-  '/analytics': 'Analytics',
-  '/process-sms': 'Import SMS',
-  '/settings': 'Settings',
-  '/profile': 'Profile',
-  '/sms-providers': 'SMS Providers',
-  '/wireframes': 'Wireframes',
-  '/wireframes/dashboard': 'Dashboard',
-  '/wireframes/onboarding': 'Onboarding',
-  '/wireframes/add-transaction': 'Add Transaction',
-  '/wireframes/reports': 'Reports',
-  '/wireframes/settings': 'Settings',
-  '/wireframes/sms-provider': 'SMS Provider',
-  '/wireframes/sms-transaction': 'SMS Transaction',
-  '/import-transactions': 'Paste & Parse',
-  '/review-sms-transactions': 'Review Details',
-  '/edit-transaction': 'Transaction',
-  '/budget/accounts': 'Accounts & Balances',
-  '/budget/set': 'Set Budget',
-  '/budget/report': 'Budget vs Actual',
-  '/budget/insights': 'Suggestions & Insights',
+  "/": "Xpensia",
+  "/home": "Xpensia",
+  "/transactions": "Transactions",
+  "/analytics": "Analytics",
+  "/process-sms": "Import SMS",
+  "/settings": "Settings",
+  "/profile": "Profile",
+  "/sms-providers": "SMS Providers",
+  "/wireframes": "Wireframes",
+  "/wireframes/dashboard": "Dashboard",
+  "/wireframes/onboarding": "Onboarding",
+  "/wireframes/add-transaction": "Add Transaction",
+  "/wireframes/reports": "Reports",
+  "/wireframes/settings": "Settings",
+  "/wireframes/sms-provider": "SMS Provider",
+  "/wireframes/sms-transaction": "SMS Transaction",
+  "/import-transactions": "Paste & Parse",
+  "/review-sms-transactions": "Review Details",
+  "/edit-transaction": "Transaction",
+  "/budget/accounts": "Accounts & Balances",
+  "/budget/set": "Set Budget",
+  "/budget/report": "Budget vs Actual",
+  "/budget/insights": "Suggestions & Insights",
 };
 
 // Navigation items that appear in the header
 export const getNavItems = () => [
-  { 
-    title: 'Home', 
-    path: '/home', 
-    icon: 'Home', 
-    description: 'Overview of your finances' 
+  {
+    title: "Home",
+    path: "/home",
+    icon: "Home",
+    description: "Overview of your finances",
   },
   {
-    title: 'Analytics',
-    path: '/analytics',
-    icon: 'PieChart',
-    description: 'Detailed reports and charts'
+    title: "Analytics",
+    path: "/analytics",
+    icon: "PieChart",
+    description: "Detailed reports and charts",
   },
   {
-    title: 'Budget',
-    path: '/budget/accounts',
-    icon: 'Scale',
-    description: 'Manage budgets and accounts'
+    title: "Budget",
+    // Opens a modal instead of linking directly
+    modal: "budget",
+    icon: "Scale",
+    description: "Manage budgets and accounts",
   },
   {
-    title: 'Transactions',
-    path: '/transactions',
-    icon: 'List',
-    description: 'View and manage your transactions'
+    title: "Transactions",
+    path: "/transactions",
+    icon: "List",
+    description: "View and manage your transactions",
   },
   {
-    title: 'Paste & Parse',
-    path: '/import-transactions',
-    icon: 'Upload',
-    description: 'Import transactions from SMS or paste'
+    title: "Paste & Parse",
+    path: "/import-transactions",
+    icon: "Upload",
+    description: "Import transactions from SMS or paste",
   },
   {
-    title: 'Import SMS',
-    path: '/process-sms',
-    icon: 'MessageSquare',
-    description: 'Import transactions from SMS'
+    title: "Import SMS",
+    path: "/process-sms",
+    icon: "MessageSquare",
+    description: "Import transactions from SMS",
   },
   {
-    title: 'Settings',
-    path: '/settings',
-    icon: 'Settings',
-    description: 'Configure app preferences'
+    title: "Settings",
+    path: "/settings",
+    icon: "Settings",
+    description: "Configure app preferences",
   },
-  { 
-    title: 'Profile', 
-    path: '/profile', 
-    icon: 'User', 
-    description: 'Manage your profile' 
+  {
+    title: "Profile",
+    path: "/profile",
+    icon: "User",
+    description: "Manage your profile",
   },
 ];


### PR DESCRIPTION
## Summary
- adjust route constants so Budget item opens a modal
- allow Budget item to toggle a dialog in desktop and mobile headers
- link to budget subpages inside the dialog

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642b6cfaa8833397890bcbd0f22d84