### PR TITLE
Update budget navigation to use popup

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
   LineChart,
   Home,
   BarChart3,
@@ -34,13 +42,7 @@ const Sidebar: React.FC = () => {
 
   ];
 
-  const [budgetOpen, setBudgetOpen] = React.useState(
-    location.pathname.startsWith('/budget')
-  );
-
-  React.useEffect(() => {
-    setBudgetOpen(location.pathname.startsWith('/budget'));
-  }, [location.pathname]);
+  const [budgetOpen, setBudgetOpen] = React.useState(false);
 
   const budgetItems = [
     { name: 'Accounts', path: '/budget/accounts', icon: <CreditCard size={18} /> },
@@ -80,7 +82,7 @@ const Sidebar: React.FC = () => {
             <li>
               <button
                 type="button"
-                onClick={() => setBudgetOpen(!budgetOpen)}
+                onClick={() => setBudgetOpen(true)}
                 className={`flex w-full items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
                   location.pathname.startsWith('/budget')
                     ? 'bg-primary text-primary-foreground'
@@ -89,27 +91,27 @@ const Sidebar: React.FC = () => {
               >
                 <Scale size={20} className="mr-3" />
                 <span className="flex-1 text-left">Budget</span>
-                <span className="ml-auto">{budgetOpen ? '▾' : '▸'}</span>
               </button>
-              {budgetOpen && (
-                <ul className="mt-1 ml-4 space-y-1">
-                  {budgetItems.map((b) => (
-                    <li key={b.path}>
-                      <Link
-                        to={b.path}
-                        className={`flex items-center px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                          isActive(b.path)
-                            ? 'bg-primary text-primary-foreground'
-                            : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                        }`}
-                      >
-                        <span className="mr-3">{b.icon}</span>
-                        {b.name}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              )}
+
+              <Dialog open={budgetOpen} onOpenChange={setBudgetOpen}>
+                <DialogContent className="sm:max-w-xs">
+                  <DialogHeader>
+                    <DialogTitle>Select Budget Page</DialogTitle>
+                  </DialogHeader>
+                  <div className="grid gap-2 py-2">
+                    {budgetItems.map((b) => (
+                      <DialogClose asChild key={b.path}>
+                        <Button asChild variant="outline" className="justify-start">
+                          <Link to={b.path} className="flex items-center gap-2">
+                            {b.icon}
+                            {b.name}
+                          </Link>
+                        </Button>
+                      </DialogClose>
+                    ))}
+                  </div>
+                </DialogContent>
+              </Dialog>
             </li>
           </ul>
         </nav>

--- a/src/pages/budget/AccountsPage.tsx
+++ b/src/pages/budget/AccountsPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -38,7 +37,6 @@ const AccountsPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1">
-        <PageHeader title="Accounts & Balances" />
         <div className="space-y-3 py-4">
           {accounts.map(acc => (
             <div key={acc.id} className="flex items-center justify-between bg-card p-3 rounded-xl">

--- a/src/pages/budget/BudgetInsightsPage.tsx
+++ b/src/pages/budget/BudgetInsightsPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useTransactions } from '@/context/TransactionContext';
 import { budgetService } from '@/services/BudgetService';
@@ -40,7 +39,6 @@ const BudgetInsightsPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1 space-y-3">
-        <PageHeader title="Suggestions & Insights" />
         {insights.map(i => (
           <Alert key={i.id} className="bg-card">
             <AlertTitle>Insight</AlertTitle>

--- a/src/pages/budget/BudgetReportPage.tsx
+++ b/src/pages/budget/BudgetReportPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { useTransactions } from '@/context/TransactionContext';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, LineChart, Line, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { budgetService } from '@/services/BudgetService';
@@ -47,7 +46,6 @@ const BudgetReportPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1 space-y-4">
-        <PageHeader title="Budget vs Actual" />
         <div className="bg-card p-4 rounded-xl">
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">

--- a/src/pages/budget/SetBudgetPage.tsx
+++ b/src/pages/budget/SetBudgetPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -62,7 +61,6 @@ const SetBudgetPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1">
-        <PageHeader title="Set Budget" />
         <div className="space-y-3 py-4">
           {budgets.map(b => (
             <div key={b.id} className="flex items-center justify-between bg-card p-3 rounded-xl">


### PR DESCRIPTION
## Summary
- open a dialog when clicking **Budget** in the sidebar
- remove inline submenus for the budget section
- tidy budget pages by dropping their additional header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686427d282688333b7b4a6252e2af126