### PR TITLE
Update budget navigation to use inline menu

### DIFF
--- a/src/pages/budget/AccountsPage.tsx
+++ b/src/pages/budget/AccountsPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -38,7 +37,6 @@ const AccountsPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1">
-        <PageHeader title="Accounts & Balances" />
         <div className="space-y-3 py-4">
           {accounts.map(acc => (
             <div key={acc.id} className="flex items-center justify-between bg-card p-3 rounded-xl">

--- a/src/pages/budget/BudgetInsightsPage.tsx
+++ b/src/pages/budget/BudgetInsightsPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useTransactions } from '@/context/TransactionContext';
 import { budgetService } from '@/services/BudgetService';
@@ -40,7 +39,6 @@ const BudgetInsightsPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1 space-y-3">
-        <PageHeader title="Suggestions & Insights" />
         {insights.map(i => (
           <Alert key={i.id} className="bg-card">
             <AlertTitle>Insight</AlertTitle>

--- a/src/pages/budget/BudgetReportPage.tsx
+++ b/src/pages/budget/BudgetReportPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { useTransactions } from '@/context/TransactionContext';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, LineChart, Line, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { budgetService } from '@/services/BudgetService';
@@ -47,7 +46,6 @@ const BudgetReportPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1 space-y-4">
-        <PageHeader title="Budget vs Actual" />
         <div className="bg-card p-4 rounded-xl">
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">

--- a/src/pages/budget/SetBudgetPage.tsx
+++ b/src/pages/budget/SetBudgetPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@/components/Layout';
-import PageHeader from '@/components/layout/PageHeader';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -62,7 +61,6 @@ const SetBudgetPage = () => {
   return (
     <Layout showBack>
       <div className="container px-1">
-        <PageHeader title="Set Budget" />
         <div className="space-y-3 py-4">
           {budgets.map(b => (
             <div key={b.id} className="flex items-center justify-between bg-card p-3 rounded-xl">


### PR DESCRIPTION
## Summary
- show budget subpages directly within the sidebar
- auto-expand the Budget submenu on budget pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686427d282688333b7b4a6252e2af126