### PR TITLE
Enable sender-aware template keys

### DIFF
--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -50,7 +50,7 @@ const SmartPaste = ({ senderHint, onTransactionsDetected }: SmartPasteProps) => 
     }
 
     try {
-      const parsed = parseSmsMessage(text);
+      const parsed = parseSmsMessage(text, senderHint);
       if (parsed.matched) {
         const bank =
           parsed.inferredFields.vendor ||

--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -33,7 +33,7 @@ export async function parseAndInferTransaction(
   senderHint?: string,
   smsId?: string
 ): Promise<ParsedTransactionResult> {
-  const parsed = parseSmsMessage(rawMessage);
+  const parsed = parseSmsMessage(rawMessage, senderHint);
 
   const transaction: Transaction = {
     id: nanoid(),

--- a/src/lib/smart-paste-engine/structureParser.ts
+++ b/src/lib/smart-paste-engine/structureParser.ts
@@ -31,7 +31,7 @@ export function normalizeDate(dateStr: string): string | undefined {
 }
 
 
-export function parseSmsMessage(rawMessage: string) {
+export function parseSmsMessage(rawMessage: string, senderHint?: string) {
   console.log('[SmartPaste] Step 1: Received raw message:', rawMessage);
 	if (!rawMessage) {
     throw new Error('Empty message passed to extractTemplateStructure');
@@ -55,7 +55,11 @@ export function parseSmsMessage(rawMessage: string) {
   console.log('[SmartPaste] Step 2: Extracted Template:', template);
   console.log('[SmartPaste] Step 3: Template Hash:', templateHash);
 
-  const matchedTemplate = getTemplateByHash(templateHash);
+  const matchedTemplate = getTemplateByHash(
+    templateHash,
+    senderHint,
+    (placeholders as any).account
+  );
   const directFields: Record<string, string> = {};
 
   if (matchedTemplate) {

--- a/src/services/SmsProcessingService.ts
+++ b/src/services/SmsProcessingService.ts
@@ -16,7 +16,7 @@ export function processSmsEntries(entries: SmsEntry[]): Transaction[] {
   return entries.map(entry => {
     try {
       // Use the smart paste engine to parse the SMS message
-      const parsedResult = parseSmsMessage(entry.message);
+      const parsedResult = parseSmsMessage(entry.message, entry.sender);
 
       // Extract relevant information from the parsed result
       const { directFields, inferredFields } = parsedResult;

--- a/src/utils/templateUtils.ts
+++ b/src/utils/templateUtils.ts
@@ -1,8 +1,10 @@
-export function loadTemplateBank(): SmartPasteTemplate[] {
-  const raw = localStorage.getItem('xpensia_structure_templates');
-  return raw ? JSON.parse(raw) : [];
+import { SmartPasteTemplate } from '@/types/template';
+
+export function loadTemplateBank(): Record<string, SmartPasteTemplate> {
+  const raw = localStorage.getItem('xpensia_template_bank');
+  return raw ? JSON.parse(raw) : {};
 }
 
-export function saveTemplateBank(templates: SmartPasteTemplate[]) {
-  localStorage.setItem('xpensia_structure_templates', JSON.stringify(templates));
+export function saveTemplateBank(templates: Record<string, SmartPasteTemplate>) {
+  localStorage.setItem('xpensia_template_bank', JSON.stringify(templates));
 }


### PR DESCRIPTION
## Summary
- index templates by `<sender>:<hash>` using new helper utils
- use dual-key lookups when learning or matching templates
- persist sender hint through parsing flows
- update SmartPaste UI and SMS processor to supply sender hints

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68643dc61ffc8333a45a9d4afcf84c2e