### PR TITLE
Add field confidence scoring and UI indicators

### DIFF
--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -53,9 +53,9 @@ const SmartPaste = ({ senderHint, onTransactionsDetected }: SmartPasteProps) => 
       const parsed = parseSmsMessage(text, senderHint);
       if (parsed.matched) {
         const bank =
-          parsed.inferredFields.vendor ||
-          parsed.directFields.vendor ||
-          parsed.directFields.fromAccount ||
+          parsed.inferredFields.vendor?.value ||
+          parsed.directFields.vendor?.value ||
+          parsed.directFields.fromAccount?.value ||
           '';
         setMatchStatus(
           `Matched template from ${bank || 'saved template'}`

--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -27,6 +27,8 @@ interface TransactionEditFormProps {
   compact?: boolean;
   /** Whether to display the notes field */
   showNotes?: boolean;
+  /** Optional confidence scores for fields */
+  fieldConfidences?: Partial<Record<keyof Transaction, number>>;
 }
 
 
@@ -35,6 +37,14 @@ function isDriven(
   drivenFields: Partial<Record<keyof Transaction, boolean>>
 ) {
   return !!drivenFields[field]
+}
+
+function hasLowConfidence(
+  field: keyof Transaction,
+  scores: Partial<Record<keyof Transaction, number>>
+) {
+  const score = scores[field]
+  return score !== undefined && score < 0.6
 }
 
 /* export function generateDefaultTitle(txn: Transaction): string {
@@ -83,6 +93,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
   onSave,
   compact = false,
   showNotes = true,
+  fieldConfidences = {},
 }) => {
   const [titleManuallyEdited, setTitleManuallyEdited] = useState(false);
   const [descriptionManuallyEdited, setDescriptionManuallyEdited] = useState(false);
@@ -482,9 +493,11 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
               'w-full text-sm',
               inputPadding,
               'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
-              darkFieldClass
+              darkFieldClass,
+              hasLowConfidence('currency', fieldConfidences) && 'border-amber-500'
             )}
             isAutoFilled={isDriven('currency', drivenFields)}
+            title={hasLowConfidence('currency', fieldConfidences) ? 'Low confidence' : undefined}
           >
             <SelectValue placeholder="Select currency" />
           </SelectTrigger>
@@ -749,11 +762,13 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
               onChange={(e) => handleChange('amount', parseFloat(e.target.value))}
             placeholder="0.00"
             required
+            title={hasLowConfidence('amount', fieldConfidences) ? 'Low confidence' : undefined}
           className={cn(
             'w-full text-sm rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
             inputPadding
           ,
-            darkFieldClass
+            darkFieldClass,
+            hasLowConfidence('amount', fieldConfidences) && 'border-amber-500'
           )}
         />
           <Button
@@ -778,13 +793,15 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
               value={editedTransaction.fromAccount || ''}
               onChange={(e) => handleChange('fromAccount', e.target.value)}
               isAutoFilled={isDriven('fromAccount', drivenFields)}
+            title={hasLowConfidence('fromAccount', fieldConfidences) ? 'Low confidence' : undefined}
             placeholder="Source account"
             required
             className={cn(
               'w-full text-sm',
               inputPadding,
               'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
-              darkFieldClass
+              darkFieldClass,
+              hasLowConfidence('fromAccount', fieldConfidences) && 'border-amber-500'
             )}
           />
           <Button type="button" variant="outline" size="icon" onClick={() => setAddAccountOpen(true)}>
@@ -840,9 +857,11 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
                 'w-full text-sm',
                 inputPadding,
                 'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
-                darkFieldClass
+                darkFieldClass,
+                hasLowConfidence('category', fieldConfidences) && 'border-amber-500'
               )}
               isAutoFilled={isDriven('category', drivenFields)}
+              title={hasLowConfidence('category', fieldConfidences) ? 'Low confidence' : undefined}
             >
               <SelectValue placeholder="Select category" />
             </SelectTrigger>
@@ -884,9 +903,11 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
                     'w-full text-sm',
                     inputPadding,
                     'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
-                    darkFieldClass
+                    darkFieldClass,
+                    hasLowConfidence('subcategory', fieldConfidences) && 'border-amber-500'
                   )}
                   isAutoFilled={isDriven('subcategory', drivenFields)}
+                  title={hasLowConfidence('subcategory', fieldConfidences) ? 'Low confidence' : undefined}
                 >
                   <SelectValue placeholder="Select subcategory" />
                 </SelectTrigger>
@@ -953,11 +974,13 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
             isAutoFilled={isDriven('vendor', drivenFields)}
             onChange={(e) => handleChange('vendor', e.target.value)}
             placeholder="e.g., Netflix"
+            title={hasLowConfidence('vendor', fieldConfidences) ? 'Low confidence' : undefined}
             className={cn(
               'w-full text-sm',
               inputPadding,
               'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
-              darkFieldClass
+              darkFieldClass,
+              hasLowConfidence('vendor', fieldConfidences) && 'border-amber-500'
             )}
           />
           <Button type="button" variant="outline" size="icon" onClick={() => setAddVendorOpen(true)}>
@@ -981,12 +1004,14 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
           value={editedTransaction.date || ''}
           onChange={(e) => handleChange('date', e.target.value)}
           isAutoFilled={isDriven('date', drivenFields)}
+          title={hasLowConfidence('date', fieldConfidences) ? 'Low confidence' : undefined}
           required
           className={cn(
             'w-full text-sm',
             inputPadding,
             'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
-            darkFieldClass
+            darkFieldClass,
+            hasLowConfidence('date', fieldConfidences) && 'border-amber-500'
           )}
         />
         {renderFeedbackIcons('date')}

--- a/src/lib/smart-paste-engine/__tests__/parseAndInferTransaction.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/parseAndInferTransaction.test.ts
@@ -9,8 +9,19 @@ jest.mock('../structureParser', () => ({
     template: 'tmpl',
     templateHash: 'hash',
     matched: true,
-    directFields: { amount: '100', currency: 'SAR', date: '2024-05-01', fromAccount: 'Bank', vendor: 'Shop' },
-    inferredFields: { type: 'expense', category: 'Food', subcategory: 'Groceries', vendor: 'Shop' },
+    directFields: {
+      amount: { value: '100', confidenceScore: 1, source: 'direct' },
+      currency: { value: 'SAR', confidenceScore: 1, source: 'direct' },
+      date: { value: '2024-05-01', confidenceScore: 1, source: 'direct' },
+      fromAccount: { value: 'Bank', confidenceScore: 1, source: 'direct' },
+      vendor: { value: 'Shop', confidenceScore: 1, source: 'direct' }
+    },
+    inferredFields: {
+      type: { value: 'expense', confidenceScore: 0.7, source: 'inferred' },
+      category: { value: 'Food', confidenceScore: 0.7, source: 'inferred' },
+      subcategory: { value: 'Groceries', confidenceScore: 0.7, source: 'inferred' },
+      vendor: { value: 'Shop', confidenceScore: 0.7, source: 'inferred' }
+    },
     defaultValues: {}
   }))
 }));

--- a/src/lib/smart-paste-engine/confidenceUtils.ts
+++ b/src/lib/smart-paste-engine/confidenceUtils.ts
@@ -1,0 +1,12 @@
+export function computeConfidenceScore(source: 'direct' | 'inferred' | 'default'): number {
+  switch (source) {
+    case 'direct':
+      return 1.0;
+    case 'inferred':
+      return 0.7;
+    case 'default':
+      return 0.3;
+    default:
+      return 0;
+  }
+}

--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -37,17 +37,20 @@ export async function parseAndInferTransaction(
 
   const transaction: Transaction = {
     id: nanoid(),
-    amount: parseFloat(parsed.directFields.amount || '0'),
-    currency: parsed.directFields.currency || 'SAR',
-    date: parsed.directFields.date || '',
-    type: (parsed.inferredFields.type as TransactionType) || 'expense',
-    category: parsed.inferredFields.category || 'Uncategorized',
-    subcategory: parsed.inferredFields.subcategory || 'none',
-    vendor: parsed.inferredFields.vendor || parsed.directFields.vendor || '',
+    amount: parseFloat(parsed.directFields.amount?.value || '0'),
+    currency: parsed.directFields.currency?.value || 'SAR',
+    date: parsed.directFields.date?.value || '',
+    type: (parsed.inferredFields.type?.value as TransactionType) || 'expense',
+    category: parsed.inferredFields.category?.value || 'Uncategorized',
+    subcategory: parsed.inferredFields.subcategory?.value || 'none',
+    vendor:
+      parsed.inferredFields.vendor?.value ||
+      parsed.directFields.vendor?.value ||
+      '',
     fromAccount:
-      parsed.directFields.fromAccount ||
-      parsed.inferredFields.fromAccount ||
-      parsed.defaultValues?.fromAccount ||
+      parsed.directFields.fromAccount?.value ||
+      parsed.inferredFields.fromAccount?.value ||
+      parsed.defaultValues?.fromAccount?.value ||
       senderHint || '',
     source: 'smart-paste',
     createdAt: new Date().toISOString(),
@@ -80,9 +83,9 @@ export async function parseAndInferTransaction(
   ];
   const fieldConfidences: Record<string, number> = {};
   fields.forEach((f) => {
-    if (parsed.directFields?.[f]) fieldConfidences[f] = 1;
-    else if (parsed.inferredFields?.[f]) fieldConfidences[f] = 0.6;
-    else if (parsed.defaultValues?.[f]) fieldConfidences[f] = 0.4;
+    if (parsed.directFields?.[f]) fieldConfidences[f] = parsed.directFields[f].confidenceScore;
+    else if (parsed.inferredFields?.[f]) fieldConfidences[f] = parsed.inferredFields[f].confidenceScore;
+    else if (parsed.defaultValues?.[f]) fieldConfidences[f] = parsed.defaultValues[f].confidenceScore;
     else fieldConfidences[f] = 0;
   });
 

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -33,6 +33,9 @@ const EditTransaction = () => {
   const senderHint = location.state?.senderHint as string | undefined;
   const isSuggested = location.state?.isSuggested as boolean | undefined;
   const confidenceScore = location.state?.confidence as number | undefined;
+  const fieldConfidences = location.state?.fieldConfidences as
+    | Record<string, number>
+    | undefined;
   const isNewTransaction = !transaction;
 
   const handleSave = (editedTransaction: Transaction) => {
@@ -131,6 +134,7 @@ const EditTransaction = () => {
               onSave={handleSave}
               compact
               showNotes={false}
+              fieldConfidences={fieldConfidences}
             />
           </CardContent>
         </Card>

--- a/src/pages/ReviewSmsTransactions.tsx
+++ b/src/pages/ReviewSmsTransactions.tsx
@@ -461,7 +461,11 @@ const toggleSkipAll = () => {
               size="sm"
               onClick={() =>
                 navigate('/edit-transaction', {
-                  state: { transaction: txn, rawMessage: txn.rawMessage },
+                  state: {
+                    transaction: txn,
+                    rawMessage: txn.rawMessage,
+                    fieldConfidences: txn.fieldConfidences,
+                  },
                 })
               }
             >

--- a/src/services/SmsProcessingService.ts
+++ b/src/services/SmsProcessingService.ts
@@ -24,19 +24,23 @@ export function processSmsEntries(entries: SmsEntry[]): Transaction[] {
       // Combine direct and inferred fields to create a transaction object
       const transaction: Transaction = {
         id: 'sms-' + Math.random().toString(36).substring(2, 15), // Generate a random ID
-        title: directFields.vendor || inferredFields.vendor || 'SMS Transaction',
-        amount: parseFloat(directFields.amount || inferredFields.amount || '0'),
-        category: inferredFields.category || 'Uncategorized',
-        subcategory: inferredFields.subcategory || 'none',
-        date: directFields.date || new Date().toISOString().split('T')[0],
-        type: (directFields.type || inferredFields.type || (parseFloat(directFields.amount || '0') > 0 ? 'income' : 'expense')) as 'income' | 'expense',
+        title: directFields.vendor?.value || inferredFields.vendor?.value || 'SMS Transaction',
+        amount: parseFloat(directFields.amount?.value || inferredFields.amount?.value || '0'),
+        category: inferredFields.category?.value || 'Uncategorized',
+        subcategory: inferredFields.subcategory?.value || 'none',
+        date: directFields.date?.value || new Date().toISOString().split('T')[0],
+        type: (directFields.type?.value || inferredFields.type?.value || (parseFloat(directFields.amount?.value || '0') > 0 ? 'income' : 'expense')) as 'income' | 'expense',
         notes: '',
         source: 'sms-import',
-        currency: directFields.currency || inferredFields.currency || 'USD',
-        fromAccount: inferredFields.fromAccount || 'Cash',
+        currency: directFields.currency?.value || inferredFields.currency?.value || 'USD',
+        fromAccount: inferredFields.fromAccount?.value || 'Cash',
         details: {
-          ...directFields,
-          ...inferredFields,
+          ...Object.fromEntries(
+            Object.entries(directFields).map(([k, v]) => [k, v.value])
+          ),
+          ...Object.fromEntries(
+            Object.entries(inferredFields).map(([k, v]) => [k, v.value])
+          ),
           sms: {
             sender: entry.sender,
             message: entry.message,


### PR DESCRIPTION
## Summary
- introduce `computeConfidenceScore` helper
- enhance `parseSmsMessage` to attach value metadata with confidence scores
- adapt consumers to read new field structure
- highlight low-confidence fields in `TransactionEditForm`

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6864470fcd20833382421c4a44963282