### PR TITLE
Add smart-paste utils tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,11 @@ export default {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
-  extensionsToTreatAsEsm: ['.ts', '.tsx']
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.app.json',
+      useESM: true
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "vite": "^6.2.6",
     "jest": "^30.0.3",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.0"
+    "@types/jest": "^29.5.0",
+    "jest-environment-jsdom": "^30.0.2"
   }
 }

--- a/src/lib/smart-paste-engine/__tests__/confidenceUtils.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/confidenceUtils.test.ts
@@ -1,0 +1,13 @@
+import { computeConfidenceScore } from '../confidenceUtils';
+
+describe('computeConfidenceScore', () => {
+  it('returns expected scores', () => {
+    expect(computeConfidenceScore('direct')).toBe(1.0);
+    expect(computeConfidenceScore('inferred')).toBe(0.7);
+    expect(computeConfidenceScore('default')).toBe(0.3);
+  });
+
+  it('returns 0 for unknown source', () => {
+    expect(computeConfidenceScore('other' as any)).toBe(0);
+  });
+});

--- a/src/lib/smart-paste-engine/__tests__/templateNormalizer.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/templateNormalizer.test.ts
@@ -1,0 +1,17 @@
+import { normalizeTemplateStructure } from '../templateNormalizer';
+import { createHash } from 'crypto';
+
+describe('normalizeTemplateStructure', () => {
+  const hash = (text: string) =>
+    createHash('sha256').update(text, 'utf8').digest('hex');
+
+  it('returns same hash for equivalent messages', () => {
+    const msg1 = 'Hello – you spent 50 SAR.';
+    const msg2 = 'Hello -    you spent  50 SAR.';
+
+    const normalized1 = normalizeTemplateStructure(msg1);
+    const normalized2 = normalizeTemplateStructure(msg2);
+
+    expect(hash(normalized1)).toBe(hash(normalized2));
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for confidenceUtils and templateNormalizer
- update Jest config to use app tsconfig and ESM
- include jest-environment-jsdom dev dependency

## Testing
- `npm test` *(fails: SmsParser and SmsImportService tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68644ef48c948333ad0658fb08c7ab96