### PR TITLE
Add stubs for Smart Paste imports

### DIFF
--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,0 +1,3 @@
+export function toast({ title, description }: { title: string; description?: string }): void {
+  console.log(title, description);
+}

--- a/src/lib/smart-paste-engine/confidenceUtils.ts
+++ b/src/lib/smart-paste-engine/confidenceUtils.ts
@@ -1,0 +1,14 @@
+export type ScoreSource = 'direct' | 'inferred' | 'default';
+
+export function computeConfidenceScore(source: ScoreSource): number {
+  switch (source) {
+    case 'direct':
+      return 1;
+    case 'inferred':
+      return 0.5;
+    case 'default':
+      return 0.2;
+    default:
+      return 0;
+  }
+}

--- a/src/lib/smart-paste-engine/keywordBankUtils.ts
+++ b/src/lib/smart-paste-engine/keywordBankUtils.ts
@@ -1,0 +1,20 @@
+export interface KeywordMapping {
+  field: string;
+  value: string | undefined;
+}
+
+export interface KeywordEntry {
+  keyword: string;
+  mappings: KeywordMapping[];
+}
+
+const KEY = 'xpensia_keyword_bank';
+
+export function loadKeywordBank(): KeywordEntry[] {
+  const raw = localStorage.getItem(KEY);
+  return raw ? JSON.parse(raw) as KeywordEntry[] : [];
+}
+
+export function saveKeywordBank(bank: KeywordEntry[]): void {
+  localStorage.setItem(KEY, JSON.stringify(bank));
+}

--- a/src/lib/smart-paste-engine/suggestionEngine.ts
+++ b/src/lib/smart-paste-engine/suggestionEngine.ts
@@ -1,0 +1,7 @@
+export function inferIndirectFields(_rawMessage: string, _direct: Record<string, string>): Record<string, string> {
+  return {};
+}
+
+export function extractVendorName(_message: string): string {
+  return '';
+}

--- a/src/lib/smart-paste-engine/templateNormalizer.ts
+++ b/src/lib/smart-paste-engine/templateNormalizer.ts
@@ -1,0 +1,3 @@
+export function normalizeTemplateStructure(template: string): string {
+  return template.toLowerCase().replace(/\s+/g, ' ').trim();
+}

--- a/src/lib/smart-paste-engine/templateUtils.ts
+++ b/src/lib/smart-paste-engine/templateUtils.ts
@@ -6,8 +6,8 @@ import { sha256 } from './sha256';
 const TEMPLATE_BANK_KEY = 'xpensia_template_bank';
 
 export function getTemplateKey(
-  sender?: string,
-  fromAccount?: string,
+  sender: string | undefined,
+  fromAccount: string | undefined,
   hash: string
 ): string {
   let base = sender?.toLowerCase().trim();

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,0 +1,9 @@
+export function v4(): string {
+  return (
+    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    })
+  );
+}

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,16 @@
+export interface TemplateStructure {
+  structure: string;
+  hash: string;
+  version: string;
+  hashAlgorithm: string;
+}
+
+export interface SmartPasteTemplate {
+  id: string;
+  template: string;
+  fields: string[];
+  rawSample: string;
+  created?: string;
+  defaultValues?: Record<string, string>;
+  structure?: TemplateStructure;
+}

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,0 +1,11 @@
+export interface Transaction {
+  id?: string;
+  amount?: number;
+  vendor: string;
+  date?: string;
+  category?: string;
+  subcategory?: string;
+  fromAccount?: string;
+  source?: string;
+  [key: string]: any;
+}

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -1,0 +1,12 @@
+export function storeTransaction(txn: any): void {
+  const key = 'transactions';
+  const raw = localStorage.getItem(key);
+  const items = raw ? JSON.parse(raw) : [];
+  const index = items.findIndex((t: any) => t.id === txn.id);
+  if (index >= 0) {
+    items[index] = txn;
+  } else {
+    items.push(txn);
+  }
+  localStorage.setItem(key, JSON.stringify(items));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "uuid": ["src/lib/uuid"]
+    },
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add missing modules for Smart Paste engine
- provide minimal template and transaction types
- stub storage utility and toast helper
- include basic tsconfig for building
- fix `getTemplateKey` signature

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6864e5e1454883339bcc3d7dcbfab8e4