### PR TITLE
Add template normalizer and SHA256 hashing

### DIFF
--- a/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
+++ b/src/lib/smart-paste-engine/saveTransactionWithLearning.ts
@@ -52,14 +52,13 @@ export function saveTransactionWithLearning(
   if (rawMessage && newTransaction.source === 'smart-paste') {
     learnFromTransaction(rawMessage, newTransaction, senderHint || '');
 
-    const { template, placeholders } = extractTemplateStructure(rawMessage);
+    const { structure, placeholders, hash: templateHash } = extractTemplateStructure(rawMessage);
     const fields = Object.keys(placeholders);
-    const templateHash = btoa(unescape(encodeURIComponent(template))).slice(0, 24);
 
     const key = getTemplateKey(senderHint, newTransaction.fromAccount, templateHash);
     const bank = loadTemplateBank();
     if (!bank[key]) {
-      saveNewTemplate(template, fields, rawMessage, senderHint, newTransaction.fromAccount);
+      saveNewTemplate(structure, fields, rawMessage, senderHint, newTransaction.fromAccount);
     }
 
     if (!silent && showPatternToast && !combineToasts) {

--- a/src/lib/smart-paste-engine/structureParser.ts
+++ b/src/lib/smart-paste-engine/structureParser.ts
@@ -10,8 +10,6 @@ import { inferIndirectFields } from './suggestionEngine';
 import { computeConfidenceScore } from './confidenceUtils';
 //import { normalizeDate } from './dateUtils';
 
-// Hashing util (replace with real hash lib if needed)
-const simpleHash = (text: string) => btoa(unescape(encodeURIComponent(text))).slice(0, 24);
 
 
 export function normalizeDate(dateStr: string): string | undefined {
@@ -43,23 +41,24 @@ export function parseSmsMessage(rawMessage: string, senderHint?: string) {
 	if (!rawMessage) {
     throw new Error('Empty message passed to extractTemplateStructure');
   }
-  let template = '';
+  let structure = '';
   let placeholders = {};
+  let templateHash = '';
   try {
     const result = extractTemplateStructure(rawMessage);
-    template = result.template;
+    structure = result.structure;
     placeholders = result.placeholders;
-	
-	if (!template) throw new Error('Extracted template is empty');
-	if (!placeholders) throw new Error('Extracted placeholders are missing');
+    templateHash = result.hash;
+
+        if (!structure) throw new Error('Extracted template is empty');
+        if (!placeholders) throw new Error('Extracted placeholders are missing');
 	
   } catch (err) {
     console.error('[SmartPaste] ❌ extractTemplateStructure failed:', err);
     throw err; // Let upstream handler deal with it
   }
 
-  const templateHash = simpleHash(template);
-  console.log('[SmartPaste] Step 2: Extracted Template:', template);
+  console.log('[SmartPaste] Step 2: Extracted Template:', structure);
   console.log('[SmartPaste] Step 3: Template Hash:', templateHash);
 
   const matchedTemplate = getTemplateByHash(
@@ -135,7 +134,7 @@ if (directFields['date']) {
 
   return {
     rawMessage,
-    template,
+    template: structure,
     templateHash,
     matched: !!matchedTemplate,
     directFields,

--- a/src/lib/smart-paste-engine/templateNormalizer.ts
+++ b/src/lib/smart-paste-engine/templateNormalizer.ts
@@ -1,0 +1,43 @@
+import { createHash } from 'crypto';
+
+export interface NormalizedTemplate {
+  structure: string;
+  hash: string;
+}
+
+/**
+ * Normalize a template string for hashing.
+ * - Converts smart punctuation to standard ASCII
+ * - Collapses whitespace
+ * - Normalizes common date and amount patterns
+ */
+export function normalizeTemplateStructure(msg: string): NormalizedTemplate {
+  if (!msg) return { structure: '', hash: createHash('sha256').update('').digest('hex') };
+
+  let text = msg.normalize('NFKD');
+
+  // Smart punctuation replacements
+  const replacements: [RegExp, string][] = [
+    [/[‘’]/g, "'"],
+    [/[“”]/g, '"'],
+    [/[–—]/g, '-']
+  ];
+  for (const [regex, rep] of replacements) {
+    text = text.replace(regex, rep);
+  }
+
+  // Collapse whitespace
+  text = text.replace(/\s+/g, ' ').trim();
+
+  // Normalize date patterns to placeholder
+  text = text.replace(/\b\d{1,2}[\/-]\d{1,2}[\/-]\d{2,4}\b/g, 'DATE');
+  text = text.replace(/\b\d{4}[\/-]\d{1,2}[\/-]\d{1,2}\b/g, 'DATE');
+
+  // Normalize numeric amounts
+  text = text.replace(/(?:\d{1,3},)*\d+(?:\.\d{1,2})?/g, 'AMOUNT');
+
+  const hash = createHash('sha256').update(text).digest('hex');
+  return { structure: text, hash };
+}
+
+export default normalizeTemplateStructure;

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -6,6 +6,8 @@ export interface SmartPasteTemplate {
   defaultValues?: Record<string, string>;
   created: string;
   rawSample?: string;
+  version?: string;
+  hashAlgorithm?: string;
 }
 
 export interface StructureTemplateEntry {

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -141,14 +141,13 @@ export function learnFromTransaction(
   txn: Transaction,
   senderHint: string = ''
 ) {
-  const { template, placeholders } = extractTemplateStructure(rawMessage);
+  const { structure, placeholders, hash: templateHash } = extractTemplateStructure(rawMessage);
   const fields = Object.keys(placeholders);
-  const templateHash = btoa(unescape(encodeURIComponent(template))).slice(0, 24);
 
   const key = getTemplateKey(senderHint, txn.fromAccount, templateHash);
   const bank = loadTemplateBank();
   if (!bank[key]) {
-    saveNewTemplate(template, fields, rawMessage, senderHint, txn.fromAccount);
+    saveNewTemplate(structure, fields, rawMessage, senderHint, txn.fromAccount);
   }
 
   // Save Keyword Mapping (Vendor → Category/Subcategory)


### PR DESCRIPTION
## Summary
- implement `normalizeTemplateStructure` for token normalization and SHA256 hashing
- compute normalized structure in `extractTemplateStructure`
- use new hash in template learning utilities
- add version and hash algorithm metadata to `SmartPasteTemplate`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ee5c73ec8333870f050726d69e7c