### PR TITLE
Add smart paste engine unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
+  testMatch: ['**/__tests__/**/*.test.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },

--- a/src/lib/smart-paste-engine/__tests__/confidenceUtils.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/confidenceUtils.test.ts
@@ -1,0 +1,15 @@
+import { computeConfidenceScore } from '../confidenceUtils';
+
+describe('computeConfidenceScore', () => {
+  it('returns 1.0 for direct', () => {
+    expect(computeConfidenceScore('direct')).toBe(1.0);
+  });
+
+  it('returns 0.7 for inferred', () => {
+    expect(computeConfidenceScore('inferred')).toBe(0.7);
+  });
+
+  it('returns 0.3 for default', () => {
+    expect(computeConfidenceScore('default')).toBe(0.3);
+  });
+});

--- a/src/lib/smart-paste-engine/__tests__/templateNormalizer.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/templateNormalizer.test.ts
@@ -1,0 +1,14 @@
+import normalizeTemplateStructure from '../templateNormalizer';
+
+describe('normalizeTemplateStructure', () => {
+  it('normalizes messages with differing whitespace and smart quotes equivalently', () => {
+    const msg1 = 'Paid 1000 SAR to “Store” on 1/2/2024';
+    const msg2 = '  Paid 1,000 SAR to "Store" on 2024-01-02  ';
+
+    const res1 = normalizeTemplateStructure(msg1);
+    const res2 = normalizeTemplateStructure(msg2);
+
+    expect(res1.structure).toBe('Paid AMOUNT SAR to "Store" on DATE');
+    expect(res1).toEqual(res2);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for computeConfidenceScore
- test template normalization hashing behavior
- ensure Jest picks up `.test.ts` files

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f026abec8333a15f979c76605789