### PR TITLE
Add SmartPaste template metadata

### DIFF
--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -8,6 +8,15 @@ export interface SmartPasteTemplate {
   rawSample?: string;
   version?: string;
   hashAlgorithm?: string;
+  meta?: TemplateMeta;
+}
+
+export interface TemplateMeta {
+  createdAt: string;
+  lastUsedAt?: string;
+  usageCount?: number;
+  successCount?: number;
+  fallbackCount?: number;
 }
 
 export interface StructureTemplateEntry {


### PR DESCRIPTION
## Summary
- introduce `TemplateMeta` interface for metadata tracking
- initialize metadata when saving templates
- ensure legacy templates get default metadata when loaded
- update template retrieval to log usage stats

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6864f71e6c0883338595c9005ab1ce42