### PR TITLE
Add getStaleTemplates util

### DIFF
--- a/src/lib/smart-paste-engine/__tests__/getStaleTemplates.test.ts
+++ b/src/lib/smart-paste-engine/__tests__/getStaleTemplates.test.ts
@@ -1,0 +1,44 @@
+import { getStaleTemplates } from '../templateUtils';
+import { SmartPasteTemplate } from '@/types/template';
+
+describe('getStaleTemplates', () => {
+  it('returns templates older than threshold', () => {
+    const oldDate = new Date(Date.now() - 100 * 86400000).toISOString();
+    const recentDate = new Date(Date.now() - 10 * 86400000).toISOString();
+    const bank: Record<string, SmartPasteTemplate> = {
+      old: {
+        id: 'old',
+        template: 't1',
+        fields: [],
+        created: '',
+        meta: { createdAt: '', lastUsedAt: oldDate }
+      },
+      recent: {
+        id: 'recent',
+        template: 't2',
+        fields: [],
+        created: '',
+        meta: { createdAt: '', lastUsedAt: recentDate }
+      }
+    };
+
+    const result = getStaleTemplates(bank, 90);
+    expect(result.map(t => t.id)).toEqual(['old']);
+  });
+
+  it('treats templates without lastUsedAt as stale', () => {
+    const bank: Record<string, SmartPasteTemplate> = {
+      stale: {
+        id: 'stale',
+        template: 't',
+        fields: [],
+        created: '',
+        meta: { createdAt: '' }
+      }
+    };
+
+    const result = getStaleTemplates(bank, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('stale');
+  });
+});

--- a/src/lib/smart-paste-engine/templateUtils.ts
+++ b/src/lib/smart-paste-engine/templateUtils.ts
@@ -150,6 +150,19 @@ export function getAllTemplates(): SmartPasteTemplate[] {
   return Object.values(loadTemplateBank());
 }
 
+export function getStaleTemplates(
+  bank: Record<string, SmartPasteTemplate>,
+  thresholdDays = 90
+): SmartPasteTemplate[] {
+  const now = Date.now();
+  return Object.values(bank).filter(t => {
+    const last = t.meta?.lastUsedAt
+      ? new Date(t.meta.lastUsedAt).getTime()
+      : 0;
+    return now - last > thresholdDays * 86400000;
+  });
+}
+
 export function extractTemplateStructure(
   message: string
 ): { structure: string; placeholders: Record<string, string>; hash: string } {


### PR DESCRIPTION
## Summary
- add `getStaleTemplates` helper in `templateUtils`
- test staleness logic of template utility

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f93653108333b1838dab422bf7e7