### PR TITLE
Add Template Health route constants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import EditTransaction from './pages/EditTransaction';
 import TrainModel from '@/pages/TrainModel';
 import BuildTemplate from '@/pages/BuildTemplate';
 import KeywordBankManager from '@/pages/KeywordBankManager';
+import TemplateHealthDashboard from '@/pages/DevTools/TemplateHealthDashboard';
 import ProcessSmsMessages from '@/pages/ProcessSmsMessages';
 import CustomParsingRules from '@/pages/CustomParsingRules';
 import ProcessVendors from '@/pages/sms/ProcessVendors';
@@ -230,6 +231,9 @@ function AppWrapper() {
       <Route path="/train-model" element={<TrainModel />} />
       <Route path="/build-template" element={<BuildTemplate />} />
       <Route path="/keyword-bank" element={<KeywordBankManager />} />
+      {process.env.NODE_ENV === 'development' && (
+        <Route path="/dev/template-health" element={<TemplateHealthDashboard />} />
+      )}
       <Route path="/custom-parsing-rules" element={<CustomParsingRules />} />
       <Route path="/settings" element={<Settings />} />
       <Route path="/process-sms" element={<ProcessSmsMessages />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   ClipboardList,
   Target,
   TrendingDown,
+  Activity,
 } from 'lucide-react';
 
 const Sidebar: React.FC = () => {
@@ -33,6 +34,14 @@ const Sidebar: React.FC = () => {
     { name: 'Build Template', path: '/build-template', icon: <BrainCircuit size={20} /> }
 
   ];
+
+  if (process.env.NODE_ENV === 'development') {
+    navItems.push({
+      name: 'Template Health',
+      path: '/dev/template-health',
+      icon: <Activity size={20} />,
+    });
+  }
 
   const [budgetOpen, setBudgetOpen] = React.useState(false);
 

--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -23,57 +23,71 @@ export const routeTitleMap: Record<string, string> = {
   "/budget/set": "Set Budget",
   "/budget/report": "Budget vs Actual",
   "/budget/insights": "Suggestions & Insights",
+  "/dev/template-health": "Template Health",
 };
 
 // Navigation items that appear in the header
-export const getNavItems = () => [
-  {
-    title: "Home",
-    path: "/home",
-    icon: "Home",
-    description: "Overview of your finances",
-  },
-  {
-    title: "Analytics",
-    path: "/analytics",
-    icon: "PieChart",
-    description: "Detailed reports and charts",
-  },
-  {
-    title: "Budget",
-    // Opens a modal instead of linking directly
-    modal: "budget",
-    icon: "Scale",
-    description: "Manage budgets and accounts",
-  },
-  {
-    title: "Transactions",
-    path: "/transactions",
-    icon: "List",
-    description: "View and manage your transactions",
-  },
-  {
-    title: "Paste & Parse",
-    path: "/import-transactions",
-    icon: "Upload",
-    description: "Import transactions from SMS or paste",
-  },
-  {
-    title: "Import SMS",
-    path: "/process-sms",
-    icon: "MessageSquare",
-    description: "Import transactions from SMS",
-  },
-  {
-    title: "Settings",
-    path: "/settings",
-    icon: "Settings",
-    description: "Configure app preferences",
-  },
-  {
-    title: "Profile",
-    path: "/profile",
-    icon: "User",
-    description: "Manage your profile",
-  },
-];
+export const getNavItems = () => {
+  const items = [
+    {
+      title: "Home",
+      path: "/home",
+      icon: "Home",
+      description: "Overview of your finances",
+    },
+    {
+      title: "Analytics",
+      path: "/analytics",
+      icon: "PieChart",
+      description: "Detailed reports and charts",
+    },
+    {
+      title: "Budget",
+      // Opens a modal instead of linking directly
+      modal: "budget",
+      icon: "Scale",
+      description: "Manage budgets and accounts",
+    },
+    {
+      title: "Transactions",
+      path: "/transactions",
+      icon: "List",
+      description: "View and manage your transactions",
+    },
+    {
+      title: "Paste & Parse",
+      path: "/import-transactions",
+      icon: "Upload",
+      description: "Import transactions from SMS or paste",
+    },
+    {
+      title: "Import SMS",
+      path: "/process-sms",
+      icon: "MessageSquare",
+      description: "Import transactions from SMS",
+    },
+    {
+      title: "Settings",
+      path: "/settings",
+      icon: "Settings",
+      description: "Configure app preferences",
+    },
+    {
+      title: "Profile",
+      path: "/profile",
+      icon: "User",
+      description: "Manage your profile",
+    },
+  ];
+
+  if (process.env.NODE_ENV === 'development') {
+    items.push({
+      title: "Template Health",
+      path: "/dev/template-health",
+      icon: "Activity",
+      description: "Template usage metrics",
+    });
+  }
+
+  return items;
+};

--- a/src/pages/DevTools/TemplateHealthDashboard.tsx
+++ b/src/pages/DevTools/TemplateHealthDashboard.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '@/components/Layout';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { loadTemplateBank } from '@/lib/smart-paste-engine/templateUtils';
+import { loadKeywordBank } from '@/lib/smart-paste-engine/keywordBankUtils';
+import { SmartPasteTemplate } from '@/types/template';
+
+interface TemplateRow {
+  key: string;
+  template: SmartPasteTemplate;
+  keywords: string[];
+}
+
+const TemplateHealthDashboard: React.FC = () => {
+  const [rows, setRows] = useState<TemplateRow[]>([]);
+  const [filter, setFilter] = useState<'all' | 'unused' | 'fallback' | 'top'>('all');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  useEffect(() => {
+    const templates = loadTemplateBank();
+    const keywordBank = loadKeywordBank();
+    const list: TemplateRow[] = Object.entries(templates).map(([key, tpl]) => {
+      const keywords = keywordBank
+        .filter(k => tpl.rawSample?.toLowerCase().includes(k.keyword.toLowerCase()))
+        .map(k => k.keyword);
+      return { key, template: tpl, keywords };
+    });
+    setRows(list);
+  }, []);
+
+  const filtered = rows.filter(r => {
+    const usage = r.template.meta?.usageCount ?? 0;
+    const fallback = r.template.meta?.fallbackCount ?? 0;
+    if (filter === 'unused') return usage === 0;
+    if (filter === 'fallback') return usage > 0 && fallback / usage >= 0.5;
+    return true;
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    const ua = a.template.meta?.usageCount ?? 0;
+    const ub = b.template.meta?.usageCount ?? 0;
+    if (sortDir === 'asc') return ua - ub;
+    return ub - ua;
+  });
+
+  const displayed = filter === 'top' ? sorted.slice(0, 20) : sorted;
+
+  const toggleSort = () => {
+    setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+  };
+
+  const renderRatio = (success: number, usage: number) => {
+    if (!usage) return '0%';
+    return `${Math.round((success / usage) * 100)}%`;
+  };
+
+  return (
+    <Layout>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Template Health</h1>
+        <ToggleGroup
+          type="single"
+          value={filter}
+          onValueChange={val => setFilter((val || 'all') as any)}
+          className="bg-muted p-1 rounded-md w-full max-w-md"
+        >
+          <ToggleGroupItem value="all" className="flex-1">All</ToggleGroupItem>
+          <ToggleGroupItem value="unused" className="flex-1">Unused</ToggleGroupItem>
+          <ToggleGroupItem value="fallback" className="flex-1">High Fallback</ToggleGroupItem>
+          <ToggleGroupItem value="top" className="flex-1">Most Used</ToggleGroupItem>
+        </ToggleGroup>
+        <div className="overflow-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead onClick={toggleSort} className="cursor-pointer">
+                  Hash
+                </TableHead>
+                <TableHead>Usage</TableHead>
+                <TableHead>Success %</TableHead>
+                <TableHead>Fallback %</TableHead>
+                <TableHead>Keywords</TableHead>
+                <TableHead>Sample</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {displayed.map(r => {
+                const usage = r.template.meta?.usageCount ?? 0;
+                const success = r.template.meta?.successCount ?? 0;
+                const fallback = r.template.meta?.fallbackCount ?? 0;
+                return (
+                  <TableRow key={r.key}>
+                    <TableCell className="font-mono text-xs">{r.template.id}</TableCell>
+                    <TableCell>{usage}</TableCell>
+                    <TableCell>{renderRatio(success, usage)}</TableCell>
+                    <TableCell>{renderRatio(fallback, usage)}</TableCell>
+                    <TableCell className="max-w-[200px] truncate">
+                      {r.keywords.join(', ') || '-'}
+                    </TableCell>
+                    <TableCell className="max-w-[300px] truncate">
+                      {r.template.rawSample || ''}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default TemplateHealthDashboard;
+


### PR DESCRIPTION
## Summary
- add `/dev/template-health` mapping in `routeTitleMap`
- expose Template Health in header navigation during development

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6864ffec46748333a8f63f052e533d0a