### PR TITLE
Implement template failure tracking

### DIFF
--- a/src/lib/smart-paste-engine/parseAndInferTransaction.ts
+++ b/src/lib/smart-paste-engine/parseAndInferTransaction.ts
@@ -2,7 +2,7 @@ import { Transaction, TransactionType } from '@/types/transaction';
 import { nanoid } from 'nanoid';
 import { parseSmsMessage } from './structureParser';
 import { loadKeywordBank } from './keywordBankUtils';
-import { getAllTemplates } from './templateUtils';
+import { getAllTemplates, incrementTemplateFailure } from './templateUtils';
 import { classifySmsViaCloud } from './cloudClassifier';
 import { logParsingFailure } from '@/utils/parsingLogger';
 import {
@@ -99,6 +99,15 @@ export async function parseAndInferTransaction(
   let origin: ParsedTransactionResult['origin'] = parsed.matched
     ? 'template'
     : 'structure';
+
+  if (parsed.matched && parsingStatus === 'failed') {
+    incrementTemplateFailure(
+      parsed.templateHash,
+      senderHint,
+      rawMessage,
+      parsed.template
+    );
+  }
 
   if (!parsed.matched || finalConfidence < 0.5) {
     try {


### PR DESCRIPTION
## Summary
- track template parse failures with in-memory counter
- log repeated failures to localStorage
- monitor failure counts in SmartPaste UI
- notify user and redirect to training page when threshold exceeded

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: network unreachable to github.com)*

------
https://chatgpt.com/codex/tasks/task_e_6865167587d88333a796ecf9db1fb719