### PR TITLE
Add template failure log page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import TrainModel from '@/pages/TrainModel';
 import BuildTemplate from '@/pages/BuildTemplate';
 import KeywordBankManager from '@/pages/KeywordBankManager';
 import TemplateHealthDashboard from '@/pages/DevTools/TemplateHealthDashboard';
+import TemplateFailureLog from '@/pages/DevTools/TemplateFailureLog';
 import ProcessSmsMessages from '@/pages/ProcessSmsMessages';
 import CustomParsingRules from '@/pages/CustomParsingRules';
 import ProcessVendors from '@/pages/sms/ProcessVendors';
@@ -232,7 +233,10 @@ function AppWrapper() {
       <Route path="/build-template" element={<BuildTemplate />} />
       <Route path="/keyword-bank" element={<KeywordBankManager />} />
       {process.env.NODE_ENV === 'development' && (
-        <Route path="/dev/template-health" element={<TemplateHealthDashboard />} />
+        <>
+          <Route path="/dev/template-health" element={<TemplateHealthDashboard />} />
+          <Route path="/dev/template-failures" element={<TemplateFailureLog />} />
+        </>
       )}
       <Route path="/custom-parsing-rules" element={<CustomParsingRules />} />
       <Route path="/settings" element={<Settings />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Target,
   TrendingDown,
   Activity,
+  Bug,
 } from 'lucide-react';
 
 const Sidebar: React.FC = () => {
@@ -40,6 +41,11 @@ const Sidebar: React.FC = () => {
       name: 'Template Health',
       path: '/dev/template-health',
       icon: <Activity size={20} />,
+    });
+    navItems.push({
+      name: 'Template Failures',
+      path: '/dev/template-failures',
+      icon: <Bug size={20} />,
     });
   }
 

--- a/src/components/header/route-constants.ts
+++ b/src/components/header/route-constants.ts
@@ -24,6 +24,7 @@ export const routeTitleMap: Record<string, string> = {
   "/budget/report": "Budget vs Actual",
   "/budget/insights": "Suggestions & Insights",
   "/dev/template-health": "Template Health",
+  "/dev/template-failures": "Template Failures",
 };
 
 // Navigation items that appear in the header
@@ -86,6 +87,12 @@ export const getNavItems = () => {
       path: "/dev/template-health",
       icon: "Activity",
       description: "Template usage metrics",
+    });
+    items.push({
+      title: "Template Failures",
+      path: "/dev/template-failures",
+      icon: "Bug",
+      description: "Failed template logs",
     });
   }
 

--- a/src/pages/DevTools/TemplateFailureLog.tsx
+++ b/src/pages/DevTools/TemplateFailureLog.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '@/components/Layout';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface FailureEntry {
+  hash: string;
+  sender?: string;
+  rawMessage: string;
+  expectedStructure: string;
+  timestamp: number;
+}
+
+interface GroupedFailure {
+  hash: string;
+  sender?: string;
+  count: number;
+  samples: string[];
+}
+
+const STORAGE_KEY = 'xpensia_template_failures';
+
+const TemplateFailureLog: React.FC = () => {
+  const [groups, setGroups] = useState<GroupedFailure[]>([]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const entries: FailureEntry[] = JSON.parse(raw);
+      const map: Record<string, GroupedFailure> = {};
+      for (const e of entries) {
+        const key = `${e.hash}::${e.sender || ''}`;
+        if (!map[key]) {
+          map[key] = { hash: e.hash, sender: e.sender, count: 0, samples: [] };
+        }
+        map[key].count += 1;
+        if (map[key].samples.length < 5) {
+          map[key].samples.push(e.rawMessage);
+        }
+      }
+      setGroups(Object.values(map));
+    } catch (err) {
+      console.error('Failed to load template failures', err);
+    }
+  }, []);
+
+  return (
+    <Layout>
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Template Failures</h1>
+        <div className="overflow-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Hash</TableHead>
+                <TableHead>Sender</TableHead>
+                <TableHead>Count</TableHead>
+                <TableHead>Samples</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {groups.map(g => (
+                <TableRow key={`${g.hash}-${g.sender}`}>
+                  <TableCell className="font-mono text-xs">{g.hash}</TableCell>
+                  <TableCell>{g.sender || '-'}</TableCell>
+                  <TableCell>{g.count}</TableCell>
+                  <TableCell className="max-w-[300px] truncate">
+                    {g.samples.join(' | ')}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default TemplateFailureLog;


### PR DESCRIPTION
## Summary
- add new `TemplateFailureLog` page under DevTools to inspect template parsing failures
- expose the page via dev routes and dev tools navigation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651956841c8333a3cb30463d9e4880