### PR TITLE
Override back action during onboarding

### DIFF
--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,10 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Layout from '@/components/Layout';
 import OnboardingSlides from '@/onboarding/OnboardingSlides';
 
 const Onboarding = () => {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const handlePopState = (event: PopStateEvent) => {
+      event.preventDefault();
+      window.history.pushState(null, '', window.location.href);
+    };
+
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
 
   const handleComplete = () => {
     localStorage.setItem('xpensia_onb_done', 'true');


### PR DESCRIPTION
## Summary
- block browser back navigation while onboarding is active

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: onnxruntime-node download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686569a5cbec8333a3077156d96e4009