### PR TITLE
Update onboarding slides to use Swiper

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
     "string-similarity": "^4.0.4",
+    "swiper": "^10.0.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "crypto-js": "^4.2.0",

--- a/src/onboarding/OnboardingSlides.tsx
+++ b/src/onboarding/OnboardingSlides.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import useEmblaCarousel from 'embla-carousel-react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
 import { motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 
@@ -33,48 +34,27 @@ interface Props {
 }
 
 const OnboardingSlides: React.FC<Props> = ({ onComplete }) => {
-  const [emblaRef, embla] = useEmblaCarousel({ loop: false });
   const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    if (!embla) return;
-    const handleSelect = () => setIndex(embla.selectedScrollSnap());
-    embla.on('select', handleSelect);
-    handleSelect();
-    return () => {
-      embla.off('select', handleSelect);
-    };
-  }, [embla]);
-
-  const handleNext = () => {
-    if (!embla) return;
-    if (index >= slides.length - 1) {
-      onComplete();
-    } else {
-      embla.scrollNext();
-    }
-  };
-
-  const handleSkip = () => {
-    onComplete();
-  };
 
   const isRtl = typeof document !== 'undefined' && document.documentElement.dir === 'rtl';
   const arrow = isRtl ? '←' : '→';
 
   return (
     <div dir="auto" className="flex flex-col h-screen overflow-y-auto justify-between pb-6">
-      <div className="flex-1" ref={emblaRef}>
-        <div className="flex h-full">
-          {slides.map((slide, i) => (
+      <Swiper
+        className="flex-1"
+        onSlideChange={(swiper) => setIndex(swiper.activeIndex)}
+        loop={false}
+      >
+        {slides.map((slide, i) => (
+          <SwiperSlide key={i} className="flex items-center">
             <motion.div
-              key={i}
-              className="flex-[0_0_100%] flex flex-col items-center justify-center text-center px-8"
+              className="flex flex-col items-center justify-center text-center px-8 w-full"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0 }}
             >
-              <img src={slide.image} alt="" className="max-h-72 mx-auto mb-6" />
+              <img src={slide.image} alt={slide.title} className="max-h-72 mx-auto mb-6" />
               <h2
                 className="mb-2 font-bold"
                 style={{ color: '#2C3E50', fontFamily: 'Roboto', fontSize: '24px' }}
@@ -88,9 +68,9 @@ const OnboardingSlides: React.FC<Props> = ({ onComplete }) => {
                 {slide.subtitle}
               </p>
             </motion.div>
-          ))}
-        </div>
-      </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
 
       <div className="flex justify-center gap-2 my-4">
         {slides.map((_, i) => (
@@ -105,16 +85,7 @@ const OnboardingSlides: React.FC<Props> = ({ onComplete }) => {
       </div>
 
       <div className="px-4">
-        {index < slides.length - 1 ? (
-          <div className="flex w-full gap-2">
-            <Button variant="ghost" className="flex-1" onClick={handleSkip}>
-              Skip
-            </Button>
-            <Button className="flex-1" onClick={handleNext}>
-              {`Next ${arrow}`}
-            </Button>
-          </div>
-        ) : (
+        {index === slides.length - 1 && (
           <Button className="w-full" onClick={onComplete}>
             {`Start the Journey ${arrow}`}
           </Button>


### PR DESCRIPTION
## Summary
- swap Embla carousel for Swiper in onboarding slides
- remove Skip/Next buttons and show "Start the Journey" only on last slide
- provide alt text for slide images
- add Swiper dependency

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68656e46ab4c8333b56782473caf0edd