### PR TITLE
Add feedback button

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@capacitor/ios": "^7.1.0",
     "@capacitor/local-notifications": "^7.0.1",
     "@capacitor/preferences": "^7.0.1",
+    "@capacitor/browser": "^7.0.1",
     "@capacitor/status-bar": "^7.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@huggingface/transformers": "^3.4.2",

--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Capacitor } from "@capacitor/core";
+import { Browser } from "@capacitor/browser";
+import { Button } from "@/components/ui/button";
+
+const GOOGLE_FORM_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLSf7y12I4Un25LCbJFvkx-NM9UeSB1abFzqZChMAQWHAcSsr-g/viewform?usp=dialog";
+
+interface FeedbackButtonProps {
+  className?: string;
+}
+
+const FeedbackButton: React.FC<FeedbackButtonProps> = ({ className }) => {
+  const handleClick = async () => {
+    try {
+      if (Capacitor.isNativePlatform()) {
+        await Browser.open({ url: GOOGLE_FORM_URL });
+      } else {
+        window.open(GOOGLE_FORM_URL, "_blank");
+      }
+    } catch (err) {
+      console.error("Failed to open feedback form:", err);
+    }
+  };
+
+  return (
+    <Button onClick={handleClick} className={className}>
+      Send Feedback
+    </Button>
+  );
+};
+
+export default FeedbackButton;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -32,12 +32,14 @@ import {
   Download,
   UploadCloud,
   Database,
+  Mail,
 } from "lucide-react";
 import { SmsReaderService } from "@/services/SmsReaderService";
 import { useToast } from "@/components/ui/use-toast";
 import { useUser } from "@/context/UserContext";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { CURRENCIES } from "@/lib/categories-data";
+import FeedbackButton from "@/components/FeedbackButton";
 import {
   updateCurrency as persistCurrency,
   getStoredTransactions,
@@ -206,7 +208,7 @@ const Settings = () => {
 
           const existing = getStoredTransactions();
           const confirmImport = window.confirm(
-            `This will add ${data.length} transactions to your existing ${existing.length}. Continue?`
+            `This will add ${data.length} transactions to your existing ${existing.length}. Continue?`,
           );
 
           if (!confirmImport) return;
@@ -434,6 +436,17 @@ const Settings = () => {
               Import
             </Button>
           </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="flex items-center text-lg font-semibold">
+            <Mail className="mr-2" size={20} />
+            <span>Feedback</span>
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Tell us what you think about the app
+          </p>
+          <FeedbackButton className="w-full" />
         </section>
 
         <section className="space-y-4">


### PR DESCRIPTION
## Summary
- include the Capacitor browser plugin
- add reusable `FeedbackButton` component
- show button on Settings page to collect feedback

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68656d857efc833384538a94ee732f7d