### PR TITLE
Fix CSS import order

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,10 @@
 
 @import './styles/design-tokens.css';
+@import './styles/spacing-system.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Import spacing system */
-@import './styles/spacing-system.css';
 
 @layer base {
   :root {


### PR DESCRIPTION
## Summary
- reorder CSS imports in `src/index.css` to follow PostCSS rules

## Testing
- `npm install` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6867a61569ec8333bd870c6fc81a6919