### PR TITLE
Adjust DashboardStats card fonts

### DIFF
--- a/src/components/DashboardStats.tsx
+++ b/src/components/DashboardStats.tsx
@@ -43,12 +43,12 @@ const DashboardStats = ({
           <Tooltip>
             <TooltipTrigger asChild>
               <Card className="overflow-hidden border border-border" role="button">
-                <CardContent className="p-3">
-                  <div className="flex items-center justify-center mb-2">
+                <CardContent className="px-2 py-1">
+                  <div className="flex items-center justify-center mb-1">
                     <ArrowUpCircle className="text-green-600 mr-2" size={18} strokeWidth={2.5} />
-                    <p className="font-bold text-sm text-foreground">Income</p>
+                    <p className="font-bold text-sm sm:text-base text-foreground">Income</p>
                   </div>
-                  <h3 className="text-left text-sm sm:text-base md:text-lg lg:text-xl font-semibold text-green-500 truncate leading-tight">
+                  <h3 className="text-left text-lg sm:text-xl md:text-2xl lg:text-3xl font-semibold text-green-500 truncate leading-tight">
                     {formatValue(income)}
                   </h3>
                   {renderSubtitle(income)}
@@ -69,12 +69,12 @@ const DashboardStats = ({
           <Tooltip>
             <TooltipTrigger asChild>
               <Card className="overflow-hidden border border-border" role="button">
-                <CardContent className="p-3">
-                  <div className="flex items-center justify-center mb-2">
+                <CardContent className="px-2 py-1">
+                  <div className="flex items-center justify-center mb-1">
                     <ArrowDownCircle className="text-red-600 mr-2" size={18} strokeWidth={2.5} />
-                    <p className="font-bold text-sm text-foreground">Expenses</p>
+                    <p className="font-bold text-sm sm:text-base text-foreground">Expenses</p>
                   </div>
-                  <h3 className="text-left text-sm sm:text-base md:text-lg lg:text-xl font-semibold text-red-500 truncate leading-tight">
+                  <h3 className="text-left text-lg sm:text-xl md:text-2xl lg:text-3xl font-semibold text-red-500 truncate leading-tight">
                     {formatValue(Math.abs(expenses))}
                   </h3>
                   {renderSubtitle(expenses)}
@@ -94,18 +94,18 @@ const DashboardStats = ({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Card className="overflow-hidden border border-border" role="button">
-                <CardContent className="p-3">
-                  <div className="flex items-center justify-center mb-2">
-                    <div className={`mr-2 ${balance >= 0 ? 'text-blue-600' : 'text-red-600'}`}>
-                      {balance >= 0 ? <TrendingUp size={18} strokeWidth={2.5} /> : <TrendingDown size={18} strokeWidth={2.5} />}
+                <Card className="overflow-hidden border border-border" role="button">
+                  <CardContent className="px-2 py-1">
+                    <div className="flex items-center justify-center mb-1">
+                      <div className={`mr-2 ${balance >= 0 ? 'text-blue-600' : 'text-red-600'}`}>
+                        {balance >= 0 ? <TrendingUp size={18} strokeWidth={2.5} /> : <TrendingDown size={18} strokeWidth={2.5} />}
+                      </div>
+                      <p className="font-bold text-sm sm:text-base text-foreground">Balance</p>
                     </div>
-                    <p className="font-bold text-sm text-foreground">Balance</p>
-                  </div>
-                  <h3 className={`text-left text-sm sm:text-base md:text-lg lg:text-xl font-semibold ${balance >= 0 ? 'text-blue-600' : 'text-red-500'} truncate leading-tight`}>
-                    {formatValue(balance)}
-                  </h3>
-                  {renderSubtitle(balance)}
+                    <h3 className={`text-left text-lg sm:text-xl md:text-2xl lg:text-3xl font-semibold ${balance >= 0 ? 'text-blue-600' : 'text-red-500'} truncate leading-tight`}>
+                      {formatValue(balance)}
+                    </h3>
+                    {renderSubtitle(balance)}
                   {previousBalance !== undefined && (
                     <p className={`text-xs flex items-center mt-1 ${isPositiveChange ? 'text-green-500' : 'text-red-500'} truncate`}>
                       {isPositiveChange ? (


### PR DESCRIPTION
## Summary
- enlarge DashboardStats numbers relative to titles
- compress top and bottom padding in DashboardStats cards

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6867b93936f083338ce33a3e239cb36f