### PR TITLE
Fix CSS import order

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,10 @@
 
 @import './styles/design-tokens.css';
+/* Import spacing system */
+@import './styles/spacing-system.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Import spacing system */
-@import './styles/spacing-system.css';
 
 @layer base {
   :root {


### PR DESCRIPTION
## Summary
- ensure that all @import statements precede other rules in `src/index.css`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c548f8848333b102e963da510780