### PR TITLE
Centralize category icons

### DIFF
--- a/src/components/transactions/TransactionCard.tsx
+++ b/src/components/transactions/TransactionCard.tsx
@@ -1,29 +1,8 @@
 
 		import React from 'react';
 		import { motion } from 'framer-motion';
-import {
-  Edit,
-  Trash2,
-  Receipt,
-  GraduationCap,
-  Gamepad2,
-  Utensils,
-  Gift,
-  HeartPulse,
-  Home,
-  Baby,
-  Bath,
-  ConciergeBell,
-  ShoppingBag,
-  ArrowLeftRight,
-  Car,
-  Plane,
-  Lightbulb,
-  CircleDollarSign,
-  Package,
-  LucideIcon,
-} from 'lucide-react';
-import { CATEGORY_COLOR_MAP } from '@/constants/categoryColors';
+import { Edit, Trash2 } from 'lucide-react';
+import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
 import { formatCurrency } from '@/utils/format-utils';
 		import { Transaction } from '@/types/transaction';
 		import { Card, CardContent } from '@/components/ui/card';
@@ -48,25 +27,6 @@ import { formatCurrency } from '@/utils/format-utils';
   }) => {
     const isIncome = transaction.amount > 0;
 
-    const iconMap: Record<string, LucideIcon> = {
-      Bills: Receipt,
-      Education: GraduationCap,
-      Entertainment: Gamepad2,
-      Food: Utensils,
-      'Gifts & Donations': Gift,
-      Health: HeartPulse,
-      Housing: Home,
-      Kids: Baby,
-      'Personal Care': Bath,
-      Services: ConciergeBell,
-      Shopping: ShoppingBag,
-      Transfer: ArrowLeftRight,
-      Transportation: Car,
-      Travel: Plane,
-      Utilities: Lightbulb,
-      Income: CircleDollarSign,
-      Other: Package,
-    };
 		  
 		  // Get emoji based on category
 		  const getEmojiForCategory = (category: string) => {
@@ -136,9 +96,13 @@ import { formatCurrency } from '@/utils/format-utils';
                                                 <div className="flex items-center text-xs text-muted-foreground">
                                                   <span className="flex items-center gap-1">
                                                     {(() => {
-                                                      const Icon = iconMap[transaction.category] || iconMap['Other'];
-                                                      const color = CATEGORY_COLOR_MAP[transaction.category] || CATEGORY_COLOR_MAP['Other'];
-                                                      return <Icon className={cn('w-6 h-6', color)} />;
+                                                      const info =
+                                                        CATEGORY_ICON_MAP[transaction.category] ||
+                                                        CATEGORY_ICON_MAP['Other'];
+                                                      const Icon = info.icon;
+                                                      return (
+                                                        <Icon className={cn('w-6 h-6', info.color)} />
+                                                      );
                                                     })()}
                                                     {transaction.category}
                                                   </span>

--- a/src/constants/categoryIconMap.ts
+++ b/src/constants/categoryIconMap.ts
@@ -1,0 +1,46 @@
+import {
+  Receipt,
+  GraduationCap,
+  Gamepad2,
+  Utensils,
+  Gift,
+  HeartPulse,
+  Home,
+  Baby,
+  Bath,
+  ConciergeBell,
+  ShoppingBag,
+  ArrowLeftRight,
+  Car,
+  Plane,
+  Lightbulb,
+  CircleDollarSign,
+  Package,
+  LucideIcon,
+} from 'lucide-react';
+
+export interface CategoryIconInfo {
+  icon: LucideIcon;
+  color: string;
+  background: string;
+}
+
+export const CATEGORY_ICON_MAP: Record<string, CategoryIconInfo> = {
+  Bills: { icon: Receipt, color: 'text-orange-600', background: 'bg-orange-100' },
+  Education: { icon: GraduationCap, color: 'text-indigo-600', background: 'bg-indigo-100' },
+  Entertainment: { icon: Gamepad2, color: 'text-purple-600', background: 'bg-purple-100' },
+  Food: { icon: Utensils, color: 'text-amber-600', background: 'bg-amber-100' },
+  'Gifts & Donations': { icon: Gift, color: 'text-pink-600', background: 'bg-pink-100' },
+  Health: { icon: HeartPulse, color: 'text-red-600', background: 'bg-red-100' },
+  Housing: { icon: Home, color: 'text-green-600', background: 'bg-green-100' },
+  Kids: { icon: Baby, color: 'text-teal-600', background: 'bg-teal-100' },
+  'Personal Care': { icon: Bath, color: 'text-fuchsia-600', background: 'bg-fuchsia-100' },
+  Services: { icon: ConciergeBell, color: 'text-yellow-600', background: 'bg-yellow-100' },
+  Shopping: { icon: ShoppingBag, color: 'text-rose-600', background: 'bg-rose-100' },
+  Transfer: { icon: ArrowLeftRight, color: 'text-emerald-600', background: 'bg-emerald-100' },
+  Transportation: { icon: Car, color: 'text-blue-600', background: 'bg-blue-100' },
+  Travel: { icon: Plane, color: 'text-cyan-600', background: 'bg-cyan-100' },
+  Utilities: { icon: Lightbulb, color: 'text-gray-600', background: 'bg-gray-100' },
+  Income: { icon: CircleDollarSign, color: 'text-lime-600', background: 'bg-lime-100' },
+  Other: { icon: Package, color: 'text-zinc-600', background: 'bg-zinc-100' },
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -9,26 +9,8 @@ import SubcategoryChart from '@/components/charts/SubcategoryChart';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTransactions } from '@/context/TransactionContext';
 import { useNavigate } from 'react-router-dom';
-import {
-  ChevronRight,
-  ShoppingBag,
-  Home,
-  Car,
-  Utensils,
-  CircleDollarSign,
-  Receipt,
-  GraduationCap,
-  Gamepad2,
-  Lightbulb,
-  Package,
-  Gift,
-  Baby,
-  Bath,
-  ConciergeBell,
-  ArrowLeftRight,
-  Plane,
-  HeartPulse,
-} from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
+import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
 import { format } from 'date-fns';
 
 import ResponsiveFAB from '@/components/dashboard/ResponsiveFAB';
@@ -136,25 +118,6 @@ const Dashboard = () => {
       return acc;
     }, {} as Record<string, number>);
 
-  const iconMap: Record<string, JSX.Element> = {
-    Bills: <Receipt className="w-6 h-6" />,
-    Education: <GraduationCap className="w-6 h-6" />,
-    Entertainment: <Gamepad2 className="w-6 h-6" />,
-    Food: <Utensils className="w-6 h-6" />,
-    'Gifts & Donations': <Gift className="w-6 h-6" />,
-    Health: <HeartPulse className="w-6 h-6" />,
-    Housing: <Home className="w-6 h-6" />,
-    Kids: <Baby className="w-6 h-6" />,
-    'Personal Care': <Bath className="w-6 h-6" />,
-    Services: <ConciergeBell className="w-6 h-6" />,
-    Shopping: <ShoppingBag className="w-6 h-6" />,
-    Transfer: <ArrowLeftRight className="w-6 h-6" />,
-    Transportation: <Car className="w-6 h-6" />,
-    Travel: <Plane className="w-6 h-6" />,
-    Utilities: <Lightbulb className="w-6 h-6" />,
-    Income: <CircleDollarSign className="w-6 h-6" />,
-    Other: <Package className="w-6 h-6" />,
-  };
 
   const formatDisplayTitle = (txn: Transaction) => {
     const base = txn.title?.trim() || 'Transaction';
@@ -287,7 +250,12 @@ const Dashboard = () => {
                     >
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">
-                          {iconMap[transaction.category] || iconMap['Other']}
+                          {(() => {
+                            const Icon =
+                              CATEGORY_ICON_MAP[transaction.category]?.icon ||
+                              CATEGORY_ICON_MAP['Other'].icon;
+                            return <Icon className="w-6 h-6" />;
+                          })()}
                           <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
                         </div>
                         <div

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,26 +9,8 @@ import SubcategoryChart from '@/components/charts/SubcategoryChart';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTransactions } from '@/context/TransactionContext';
 import { useNavigate } from 'react-router-dom';
-import {
-  ChevronRight,
-  ShoppingBag,
-  Home as HomeIcon,
-  Car,
-  Utensils,
-  CircleDollarSign,
-  Receipt,
-  GraduationCap,
-  Gamepad2,
-  Lightbulb,
-  Package,
-  Gift,
-  Baby,
-  Bath,
-  ConciergeBell,
-  ArrowLeftRight,
-  Plane,
-  HeartPulse,
-} from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
+import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
 import { format } from 'date-fns';
 
 import ResponsiveFAB from '@/components/dashboard/ResponsiveFAB';
@@ -143,25 +125,6 @@ const Home = () => {
       return acc;
     }, {} as Record<string, number>);
 
-  const iconMap: Record<string, JSX.Element> = {
-    Bills: <Receipt className="w-6 h-6" />,
-    Education: <GraduationCap className="w-6 h-6" />,
-    Entertainment: <Gamepad2 className="w-6 h-6" />,
-    Food: <Utensils className="w-6 h-6" />,
-    'Gifts & Donations': <Gift className="w-6 h-6" />,
-    Health: <HeartPulse className="w-6 h-6" />,
-    Housing: <HomeIcon className="w-6 h-6" />,
-    Kids: <Baby className="w-6 h-6" />,
-    'Personal Care': <Bath className="w-6 h-6" />,
-    Services: <ConciergeBell className="w-6 h-6" />,
-    Shopping: <ShoppingBag className="w-6 h-6" />,
-    Transfer: <ArrowLeftRight className="w-6 h-6" />,
-    Transportation: <Car className="w-6 h-6" />,
-    Travel: <Plane className="w-6 h-6" />,
-    Utilities: <Lightbulb className="w-6 h-6" />,
-    Income: <CircleDollarSign className="w-6 h-6" />,
-    Other: <Package className="w-6 h-6" />,
-  };
 
   const formatDisplayTitle = (txn: Transaction) => {
     const base = txn.title?.trim() || 'Transaction';
@@ -298,7 +261,12 @@ const Home = () => {
                     >
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">
-                          {iconMap[transaction.category] || iconMap['Other']}
+                          {(() => {
+                            const Icon =
+                              CATEGORY_ICON_MAP[transaction.category]?.icon ||
+                              CATEGORY_ICON_MAP['Other'].icon;
+                            return <Icon className="w-6 h-6" />;
+                          })()}
                           <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
                         </div>
                         <div


### PR DESCRIPTION
## Summary
- add a `CATEGORY_ICON_MAP` constant for icon, color and background
- use the shared icon map in `Home`, `Dashboard`, and `TransactionCard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aafb7823483338266ba41c22abd83