### PR TITLE
Display transaction type icons

### DIFF
--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -13,6 +13,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { format } from 'date-fns';
+import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
+import { TYPE_ICON_MAP } from '@/constants/typeIconMap';
 
 interface TransactionListProps {
   transactions: Transaction[];
@@ -119,8 +121,15 @@ const TransactionList: React.FC<TransactionListProps> = ({
   };
 
   const renderCategory = (transaction: Transaction) => {
+    const catInfo = CATEGORY_ICON_MAP[transaction.category] || CATEGORY_ICON_MAP['Other'];
+    const CatIcon = catInfo.icon;
+    const typeInfo = TYPE_ICON_MAP[transaction.type];
+    const TypeIcon = typeInfo.icon;
+
     return (
-      <div className="flex items-center">
+      <div className="flex items-center gap-1">
+        <CatIcon className={`w-4 h-4 ${catInfo.color}`} />
+        <TypeIcon className={`w-4 h-4 ${typeInfo.color}`} />
         <span className="text-sm">{transaction.category}</span>
       </div>
     );
@@ -198,11 +207,8 @@ const TransactionList: React.FC<TransactionListProps> = ({
               </div>
               
               <div className="flex justify-between items-center">
-                <div className="flex items-center space-x-2">
-                  {renderType(transaction.type)}
-                  <span className="text-sm text-muted-foreground">
-                    {transaction.category}
-                  </span>
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  {renderCategory(transaction)}
                 </div>
                 
                 <DropdownMenu>

--- a/src/constants/typeIconMap.ts
+++ b/src/constants/typeIconMap.ts
@@ -1,0 +1,31 @@
+import {
+  ArrowUpRight,
+  ArrowDownRight,
+  ArrowLeftRight,
+  LucideIcon
+} from 'lucide-react';
+
+export interface TypeIconInfo {
+  icon: LucideIcon;
+  color: string;
+  background: string;
+}
+
+export const TYPE_ICON_MAP: Record<'income' | 'expense' | 'transfer', TypeIconInfo> = {
+  income: {
+    icon: ArrowUpRight,
+    color: 'text-success',
+    background: 'bg-success/10'
+  },
+  expense: {
+    icon: ArrowDownRight,
+    color: 'text-destructive',
+    background: 'bg-destructive/10'
+  },
+  transfer: {
+    icon: ArrowLeftRight,
+    color: 'text-info',
+    background: 'bg-info/10'
+  }
+};
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import { useTransactions } from '@/context/TransactionContext';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
+import { TYPE_ICON_MAP } from '@/constants/typeIconMap';
 import { format } from 'date-fns';
 
 import ResponsiveFAB from '@/components/dashboard/ResponsiveFAB';
@@ -251,10 +252,16 @@ const Dashboard = () => {
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">
                           {(() => {
-                            const Icon =
+                            const CatIcon =
                               CATEGORY_ICON_MAP[transaction.category]?.icon ||
                               CATEGORY_ICON_MAP['Other'].icon;
-                            return <Icon className="w-6 h-6" />;
+                            const TypeIcon = TYPE_ICON_MAP[transaction.type].icon;
+                            return (
+                              <>
+                                <CatIcon className="w-5 h-5" />
+                                <TypeIcon className={`w-4 h-4 ${TYPE_ICON_MAP[transaction.type].color}`} />
+                              </>
+                            );
                           })()}
                           <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
                         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,6 +11,7 @@ import { useTransactions } from '@/context/TransactionContext';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
 import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
+import { TYPE_ICON_MAP } from '@/constants/typeIconMap';
 import { format } from 'date-fns';
 
 import ResponsiveFAB from '@/components/dashboard/ResponsiveFAB';
@@ -262,10 +263,16 @@ const Home = () => {
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">
                           {(() => {
-                            const Icon =
+                            const CatIcon =
                               CATEGORY_ICON_MAP[transaction.category]?.icon ||
                               CATEGORY_ICON_MAP['Other'].icon;
-                            return <Icon className="w-6 h-6" />;
+                            const TypeIcon = TYPE_ICON_MAP[transaction.type].icon;
+                            return (
+                              <>
+                                <CatIcon className="w-5 h-5" />
+                                <TypeIcon className={`w-4 h-4 ${TYPE_ICON_MAP[transaction.type].color}`} />
+                              </>
+                            );
                           })()}
                           <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>
                         </div>


### PR DESCRIPTION
## Summary
- map `income`, `expense` and `transfer` to lucide icons in `TYPE_ICON_MAP`
- show category and type icons in transaction list rows
- display type icons in recent lists on the Home and Dashboard pages

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab385fd4c8333ba40892067a7deaa