### PR TITLE
Add CategoryIcon component

### DIFF
--- a/src/components/CategoryIcon.tsx
+++ b/src/components/CategoryIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
+import { cn } from '@/lib/utils';
+
+interface CategoryIconProps {
+  category: string;
+  size?: number;
+}
+
+const CategoryIcon: React.FC<CategoryIconProps> = ({ category, size = 24 }) => {
+  const info = CATEGORY_ICON_MAP[category] || CATEGORY_ICON_MAP['Other'];
+  const Icon = info.icon;
+  const containerSize = `${size}px`;
+  const iconSize = size * 0.6;
+  return (
+    <div
+      className={cn('flex items-center justify-center rounded-full', info.background)}
+      style={{ width: containerSize, height: containerSize }}
+    >
+      <Icon className={info.color} size={iconSize} />
+    </div>
+  );
+};
+
+export default CategoryIcon;

--- a/src/components/transactions/TransactionCard.tsx
+++ b/src/components/transactions/TransactionCard.tsx
@@ -2,8 +2,8 @@
 		import React from 'react';
 		import { motion } from 'framer-motion';
 import { Edit, Trash2 } from 'lucide-react';
-import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
 import { formatCurrency } from '@/utils/format-utils';
+import CategoryIcon from '@/components/CategoryIcon';
 		import { Transaction } from '@/types/transaction';
 		import { Card, CardContent } from '@/components/ui/card';
 		import { Button } from '@/components/ui/button';
@@ -95,15 +95,7 @@ import { formatCurrency } from '@/utils/format-utils';
 						<h3 className="font-medium text-sm line-clamp-1">{transaction.title}</h3>
                                                 <div className="flex items-center text-xs text-muted-foreground">
                                                   <span className="flex items-center gap-1">
-                                                    {(() => {
-                                                      const info =
-                                                        CATEGORY_ICON_MAP[transaction.category] ||
-                                                        CATEGORY_ICON_MAP['Other'];
-                                                      const Icon = info.icon;
-                                                      return (
-                                                        <Icon className={cn('w-6 h-6', info.color)} />
-                                                      );
-                                                    })()}
+                                                    <CategoryIcon category={transaction.category} size={24} />
                                                     {transaction.category}
                                                   </span>
                                                   <span className="mx-1">•</span>

--- a/src/components/transactions/TransactionList.tsx
+++ b/src/components/transactions/TransactionList.tsx
@@ -13,8 +13,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { format } from 'date-fns';
-import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
 import { TYPE_ICON_MAP } from '@/constants/typeIconMap';
+import CategoryIcon from '@/components/CategoryIcon';
 
 interface TransactionListProps {
   transactions: Transaction[];
@@ -121,14 +121,12 @@ const TransactionList: React.FC<TransactionListProps> = ({
   };
 
   const renderCategory = (transaction: Transaction) => {
-    const catInfo = CATEGORY_ICON_MAP[transaction.category] || CATEGORY_ICON_MAP['Other'];
-    const CatIcon = catInfo.icon;
     const typeInfo = TYPE_ICON_MAP[transaction.type];
     const TypeIcon = typeInfo.icon;
 
     return (
       <div className="flex items-center gap-1">
-        <CatIcon className={`w-4 h-4 ${catInfo.color}`} />
+        <CategoryIcon category={transaction.category} size={16} />
         <TypeIcon className={`w-4 h-4 ${typeInfo.color}`} />
         <span className="text-sm">{transaction.category}</span>
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,8 +10,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTransactions } from '@/context/TransactionContext';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
-import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
 import { TYPE_ICON_MAP } from '@/constants/typeIconMap';
+import CategoryIcon from '@/components/CategoryIcon';
 import { format } from 'date-fns';
 
 import ResponsiveFAB from '@/components/dashboard/ResponsiveFAB';
@@ -251,16 +251,11 @@ const Dashboard = () => {
                     >
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">
+                          <CategoryIcon category={transaction.category} size={20} />
                           {(() => {
-                            const CatIcon =
-                              CATEGORY_ICON_MAP[transaction.category]?.icon ||
-                              CATEGORY_ICON_MAP['Other'].icon;
                             const TypeIcon = TYPE_ICON_MAP[transaction.type].icon;
                             return (
-                              <>
-                                <CatIcon className="w-5 h-5" />
-                                <TypeIcon className={`w-4 h-4 ${TYPE_ICON_MAP[transaction.type].color}`} />
-                              </>
+                              <TypeIcon className={`w-4 h-4 ${TYPE_ICON_MAP[transaction.type].color}`} />
                             );
                           })()}
                           <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,8 +10,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTransactions } from '@/context/TransactionContext';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight } from 'lucide-react';
-import { CATEGORY_ICON_MAP } from '@/constants/categoryIconMap';
 import { TYPE_ICON_MAP } from '@/constants/typeIconMap';
+import CategoryIcon from '@/components/CategoryIcon';
 import { format } from 'date-fns';
 
 import ResponsiveFAB from '@/components/dashboard/ResponsiveFAB';
@@ -262,16 +262,11 @@ const Home = () => {
                     >
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 min-w-0">
+                          <CategoryIcon category={transaction.category} size={20} />
                           {(() => {
-                            const CatIcon =
-                              CATEGORY_ICON_MAP[transaction.category]?.icon ||
-                              CATEGORY_ICON_MAP['Other'].icon;
                             const TypeIcon = TYPE_ICON_MAP[transaction.type].icon;
                             return (
-                              <>
-                                <CatIcon className="w-5 h-5" />
-                                <TypeIcon className={`w-4 h-4 ${TYPE_ICON_MAP[transaction.type].color}`} />
-                              </>
+                              <TypeIcon className={`w-4 h-4 ${TYPE_ICON_MAP[transaction.type].color}`} />
                             );
                           })()}
                           <span className="font-medium line-clamp-1">{formatDisplayTitle(transaction)}</span>


### PR DESCRIPTION
## Summary
- centralize category icon rendering with `CategoryIcon`
- use the new component in transaction card, list, home, and dashboard views

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686abbd563908333a926777a504bfef9