### PR TITLE
Add TransactionList component tests

### DIFF
--- a/src/components/transactions/__tests__/TransactionList.test.tsx
+++ b/src/components/transactions/__tests__/TransactionList.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TransactionList from '../TransactionList';
+import { formatCurrency } from '@/utils/format-utils';
+import type { Transaction } from '@/types/transaction';
+import { vi } from 'vitest';
+
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: () => false,
+}));
+
+describe('TransactionList', () => {
+  const transaction: Transaction = {
+    id: '1',
+    title: 'Coffee',
+    amount: 4.5,
+    category: 'Food',
+    date: '2024-05-01',
+    type: 'income',
+    source: 'manual',
+  };
+
+  it('renders transaction title, amount and category', () => {
+    render(<TransactionList transactions={[transaction]} />);
+
+    expect(screen.getByText(transaction.title)).toBeInTheDocument();
+    expect(
+      screen.getByText(formatCurrency(transaction.amount, 'USD')),
+    ).toBeInTheDocument();
+    expect(screen.getByText(transaction.category)).toBeInTheDocument();
+  });
+
+  it('calls onEdit and onDelete when buttons clicked', () => {
+    const handleEdit = vi.fn();
+    const handleDelete = vi.fn();
+    render(
+      <TransactionList
+        transactions={[transaction]}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />,
+    );
+
+    const row = screen.getByText(transaction.title).closest('tr')!;
+    const buttons = within(row).getAllByRole('button');
+    fireEvent.click(buttons[0]);
+    expect(handleEdit).toHaveBeenCalledWith(transaction);
+
+    fireEvent.click(buttons[1]);
+    expect(handleDelete).toHaveBeenCalledWith(transaction.id);
+  });
+
+  it('shows loading skeleton when isLoading', () => {
+    const { container } = render(
+      <TransactionList transactions={[transaction]} isLoading />,
+    );
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('renders empty message when no transactions', () => {
+    render(
+      <TransactionList transactions={[]} emptyMessage="Nothing here" />,
+    );
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for TransactionList component

## Testing
- `npx vitest run src/components/transactions/__tests__/TransactionList.test.tsx`
- `npm test -- -t TransactionList` *(fails: jest is not defined in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ac9628f00833395a8a0176d223b90