### PR TITLE
Add DashboardStats tests

### DIFF
--- a/src/components/__tests__/DashboardStats.test.tsx
+++ b/src/components/__tests__/DashboardStats.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DashboardStats from '../DashboardStats';
+import { formatCurrency } from '@/lib/formatters';
+
+describe('DashboardStats', () => {
+  it('renders income, expenses and balance', () => {
+    render(
+      <DashboardStats income={1000} expenses={200} balance={800} />
+    );
+
+    expect(screen.getByText(formatCurrency(1000))).toBeInTheDocument();
+    expect(screen.getByText(formatCurrency(200))).toBeInTheDocument();
+    expect(screen.getByText(formatCurrency(800))).toBeInTheDocument();
+  });
+
+  it('shows percentage change when previousBalance provided', () => {
+    render(
+      <DashboardStats income={500} expenses={200} balance={300} previousBalance={200} />
+    );
+
+    expect(screen.getByText(/50\.0% from last month/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for DashboardStats component
- confirm DashboardOverview no longer exists and DashboardStats is the summary component

## Testing
- `npx vitest run` *(fails: Cannot find package 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_686acc5a23c88333ba5f918003ad04b3