### PR TITLE
Fix app version persistence after update

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -103,6 +103,7 @@ async function checkForUpdates() {
   const pendingVersion = localStorage.getItem('pending_update')
   if (pendingVersion) {
     alert("Xpensia Updated! You're now on version " + pendingVersion)
+    localStorage.setItem('app_version', pendingVersion)
     localStorage.removeItem('pending_update')
   }
 
@@ -145,8 +146,8 @@ async function checkForUpdates() {
         url: manifest.url || 'https://xpensia-505ac.web.app/www.zip'
       })
       localStorage.setItem('pending_update', latestVersion)
-      await CapacitorUpdater.set(downloaded) // reloads automatically
       localStorage.setItem('app_version', latestVersion)
+      await CapacitorUpdater.set(downloaded) // reloads automatically
     } else {
       if (process.env.NODE_ENV === 'development') console.log('✅ Web bundle up-to-date')
       await CapacitorUpdater.notifyAppReady()


### PR DESCRIPTION
## Summary
- ensure `app_version` is stored when a pending update is detected
- store version before applying Capgo update so the value persists across reloads

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adf974ea48333b2d6939b8548cda2