### PR TITLE
Fix Android build for Java 21

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,8 +27,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        // Target Java 21 for the application module
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     // Optional: if you're using Kotlin in this module
@@ -39,7 +40,7 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,9 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
+      // Use Java 21 for compiling capacitor modules
+      sourceCompatibility JavaVersion.VERSION_21
+      targetCompatibility JavaVersion.VERSION_21
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.kotlin_version = '1.9.10' // Compatible with Java 17
+    ext.kotlin_version = '1.9.10' // Compatible with Java 21
     repositories {
         google()
         mavenCentral()
@@ -20,7 +20,7 @@ allprojects {
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
-            jvmTarget = "17"
+            jvmTarget = "21"
         }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,7 +10,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
-org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-17.0.12.7-hotspot
+# Use JDK 21 for building Android modules
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64
 android.builder.sdkDownload=true
 
 # When configured, Gradle will run in incubating parallel mode.
@@ -26,7 +27,7 @@ android.useAndroidX=true
 
 
 # Removed duplicate - Java home is set above
-android.kotlinOptions.jvmTarget=17
-android.compileOptions.sourceCompatibility=17
-android.compileOptions.targetCompatibility=17
+android.kotlinOptions.jvmTarget=21
+android.compileOptions.sourceCompatibility=21
+android.compileOptions.targetCompatibility=21
 android.suppressUnsupportedCompileSdk=35

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -2,9 +2,10 @@ ext {
     minSdkVersion = 23
     compileSdkVersion = 35
     targetSdkVersion = 35
-    javaVersion = JavaVersion.VERSION_17
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    // Build plugins require JDK 21
+    javaVersion = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'


### PR DESCRIPTION
## Summary
- update Gradle configuration to use JDK 21
- bump compile options to Java 21

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c155363508333960041a2bafbe868