### PR TITLE
Fix Android build by targeting Java 17

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,9 +27,9 @@ android {
     }
 
     compileOptions {
-        // Target Java 21 for the application module
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        // Target Java 17 for the application module
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     // Optional: if you're using Kotlin in this module
@@ -40,7 +40,7 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,9 +2,9 @@
 
 android {
   compileOptions {
-      // Use Java 21 for compiling capacitor modules
-      sourceCompatibility JavaVersion.VERSION_21
-      targetCompatibility JavaVersion.VERSION_21
+      // Use Java 17 for compiling capacitor modules
+      sourceCompatibility JavaVersion.VERSION_17
+      targetCompatibility JavaVersion.VERSION_17
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
-            jvmTarget = "21"
+            jvmTarget = "17"
         }
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -27,7 +27,7 @@ android.useAndroidX=true
 
 
 # Removed duplicate - Java home is set above
-android.kotlinOptions.jvmTarget=21
-android.compileOptions.sourceCompatibility=21
-android.compileOptions.targetCompatibility=21
+android.kotlinOptions.jvmTarget=17
+android.compileOptions.sourceCompatibility=17
+android.compileOptions.targetCompatibility=17
 android.suppressUnsupportedCompileSdk=35

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -3,9 +3,10 @@ ext {
     compileSdkVersion = 35
     targetSdkVersion = 35
     // Build plugins require JDK 21
-    javaVersion = JavaVersion.VERSION_21
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    // Use Java 17 for Android compilation
+    javaVersion = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     androidxActivityVersion = '1.9.2'
     androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'


### PR DESCRIPTION
## Summary
- target Java 17 in Android gradle files

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c16d96ad48333979847e7dade5871