### PR TITLE
Fix missing comma in capacitor config

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -11,9 +11,9 @@ const config: CapacitorConfig = {
     cleartext: true
   },
   plugins: {
-	  CapacitorUpdater: {
+          CapacitorUpdater: {
       autoUpdate: false
-    }
+    },
     SplashScreen: {
       launchShowDuration: 0
     },


### PR DESCRIPTION
## Summary
- fix trailing comma after CapacitorUpdater plugin entry

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ccf05afdc83339a0dc6e88ff5ca9d