### PR TITLE
Clean up build scripts and type comments

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,12 +40,6 @@ android {
     }
 }
 
-// ❌ REMOVE THIS — not valid in Groovy build.gradle
-// java {
-//     toolchain {
-//         languageVersion = JavaLanguageVersion.of(17)
-//     }
-// }
 
 repositories {
     flatDir {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
 		classpath "com.android.tools.build:gradle:8.3.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.google.gms:google-services:4.3.15" // ✅ Add this line
+        classpath "com.google.gms:google-services:4.3.15"
     }
 }
 

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -44,7 +44,7 @@ export const errorSeverityDefaults: Record<ErrorType, ErrorSeverity> = {
   [ErrorType.AUTH]: ErrorSeverity.ERROR,
   [ErrorType.TIMEOUT]: ErrorSeverity.WARNING,
   [ErrorType.TRANSACTION]: ErrorSeverity.ERROR,
-  [ErrorType.FORMATTING]: ErrorSeverity.WARNING, // Add this line for the formatting error severity
+  [ErrorType.FORMATTING]: ErrorSeverity.WARNING,
   [ErrorType.UNKNOWN]: ErrorSeverity.ERROR
 };
 


### PR DESCRIPTION
## Summary
- remove leftover comment from `android/build.gradle`
- clean up invalid java toolchain block in `android/app/build.gradle`
- drop stray explanatory comment in `error.ts`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ccf93ba248333bf1d484061e0aecc