### PR TITLE
Update capacitor plugin dependencies to v6

### DIFF
--- a/capacitor-background-sms-listener/package-lock.json
+++ b/capacitor-background-sms-listener/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@capacitor/core": "latest"
+        "@capacitor/core": "^6.0.0"
       },
       "peerDependencies": {
-        "@capacitor/core": "latest"
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-2zCnA6RJeZ9ec4470o8QMZEQTWpekw9FNoqm5TLc10jeCrhvHVI8MPgxdZVc3mOdFlyieYu4AS1fNxSqbS57Pw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/capacitor-background-sms-listener/package.json
+++ b/capacitor-background-sms-listener/package.json
@@ -13,10 +13,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^6.0.0"
   },
   "peerDependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^6.0.0"
   },
   "files": [
     "dist/",

--- a/capacitor-sms-reader/package.json
+++ b/capacitor-sms-reader/package.json
@@ -36,10 +36,10 @@
     }
   },
   "devDependencies": {
-    "@capacitor/android": "^5.0.0",
-    "@capacitor/core": "^5.0.0"
+    "@capacitor/android": "^6.0.0",
+    "@capacitor/core": "^6.0.0"
   },
   "peerDependencies": {
-    "@capacitor/core": "^5.0.0"
+    "@capacitor/core": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- update capacitor-core requirement for background SMS listener plugin
- update capacitor versions for SMS reader plugin
- regenerate lockfile for background SMS listener plugin

## Testing
- `npm install` in `capacitor-background-sms-listener`

------
https://chatgpt.com/codex/tasks/task_e_686cd2d46f808333b7534cece4f08dc0