### PR TITLE
Fix Capacitor peer dependency conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
-        "@capacitor-firebase/analytics": "^7.2.0",
+        "@capacitor-firebase/analytics": "^6.3.1",
         "@capacitor/android": "6.2.1",
         "@capacitor/app": "6.0.2",
         "@capacitor/browser": "6.0.5",
@@ -21,7 +21,7 @@
         "@capacitor/local-notifications": "6.1.2",
         "@capacitor/preferences": "6.0.3",
         "@capacitor/status-bar": "6.0.2",
-        "@capgo/capacitor-updater": "^7.7.0",
+        "@capgo/capacitor-updater": "^6.14.17",
         "@hookform/resolvers": "^3.9.0",
         "@huggingface/transformers": "^3.4.2",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -122,41 +122,21 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@capacitor/core": "latest"
+        "@capacitor/core": "^6.0.0"
       },
       "peerDependencies": {
-        "@capacitor/core": "latest"
+        "@capacitor/core": "^6.0.0"
       }
     },
     "capacitor-sms-reader": {
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@capacitor/android": "^5.0.0",
-        "@capacitor/core": "^5.0.0"
+        "@capacitor/android": "^6.0.0",
+        "@capacitor/core": "^6.0.0"
       },
       "peerDependencies": {
-        "@capacitor/core": "^5.0.0"
-      }
-    },
-    "capacitor-sms-reader/node_modules/@capacitor/android": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-5.7.8.tgz",
-      "integrity": "sha512-ooWclwcuW0dy3YfqgoozkHkjatX8H2fb2/RwRsJa3cew1P1lUXIXri3Dquuy4LdqFAJA7UHcJ19Bl/6UKdsZYA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": "^5.7.0"
-      }
-    },
-    "capacitor-sms-reader/node_modules/@capacitor/core": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.7.8.tgz",
-      "integrity": "sha512-rrZcm/2vJM0WdWRQup1TUidbjQV9PfIadSkV4rAGLD7R6PuzZSMPGT0gmoZzCRlXkqrazrWWDkurei3ozU02FA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -749,9 +729,9 @@
       "license": "MIT"
     },
     "node_modules/@capacitor-firebase/analytics": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor-firebase/analytics/-/analytics-7.2.0.tgz",
-      "integrity": "sha512-6a1f4MXdQhfP7I4nzjx5Bdg7LGIcgRMVWTFSMGkuygLNJ66ZkgdjLAeh36pYtd22qkPtVOu61DnsJjz6iWqGng==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@capacitor-firebase/analytics/-/analytics-6.3.1.tgz",
+      "integrity": "sha512-0XNCHzUgaOg2HILwtChUYlDtWhuoCorzMbulNXHBlqyA1eYTtyKLjyD8t7xBfvzSCqb/2xXjGXX1jClUAY91HQ==",
       "funding": [
         {
           "type": "github",
@@ -764,8 +744,8 @@
       ],
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@capacitor/core": ">=7.0.0",
-        "firebase": "^11.2.0"
+        "@capacitor/core": "^6.0.0",
+        "firebase": "^10.9.0 || ^11.0.0"
       },
       "peerDependenciesMeta": {
         "firebase": {
@@ -905,12 +885,12 @@
       }
     },
     "node_modules/@capgo/capacitor-updater": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@capgo/capacitor-updater/-/capacitor-updater-7.7.1.tgz",
-      "integrity": "sha512-GFymcenxsbxrriuxa7P7lzIM5hVAjHzN3z3Og3C8vb70QFO+GonCDHsgdf3NIVM0OPh5UM6gmhhFhe6sE/WoiQ==",
+      "version": "6.14.17",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-updater/-/capacitor-updater-6.14.17.tgz",
+      "integrity": "sha512-d8Xvn22tiE0aipIMz3kvHSabWQPTEuZGCD0Zzb2L+QHKtlm8TtjGV9JUo/AUvRmMBVFJ3B9L4GyPgVkLvnpWsA==",
       "license": "MPL-2.0",
       "peerDependencies": {
-        "@capacitor/core": ">=7.0.0"
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepare:plugins": "bash scripts/build-plugins.sh"
   },
   "dependencies": {
-    "@capacitor-firebase/analytics": "^7.2.0",
+    "@capacitor-firebase/analytics": "^6.3.1",
     "@capacitor/android": "6.2.1",
     "@capacitor/app": "6.0.2",
     "@capacitor/browser": "6.0.5",
@@ -26,7 +26,7 @@
     "@capacitor/local-notifications": "6.1.2",
     "@capacitor/preferences": "6.0.3",
     "@capacitor/status-bar": "6.0.2",
-    "@capgo/capacitor-updater": "^7.7.0",
+    "@capgo/capacitor-updater": "^6.14.17",
     "@hookform/resolvers": "^3.9.0",
     "@huggingface/transformers": "^3.4.2",
     "@radix-ui/react-accordion": "^1.2.0",


### PR DESCRIPTION
## Summary
- sync Capacitor plugin versions with the rest of the project

## Testing
- `npm install --ignore-scripts`
- `npm test` *(fails: Jest not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686cd547ac08833398ea67a327d2f24f