### PR TITLE
Fix background SMS permission request

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -34,7 +34,7 @@ import {
   Database,
   Mail,
 } from "lucide-react";
-import { SmsReaderService } from "@/services/SmsReaderService";
+import { smsPermissionService } from "@/services/SmsPermissionService";
 import { useToast } from "@/components/ui/use-toast";
 import { useUser } from "@/context/UserContext";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -107,8 +107,13 @@ const Settings = () => {
 
 
   const handleBackgroundSmsChange = async (checked: boolean) => {
+
     if (checked) {
-      const granted = await SmsReaderService.checkOrRequestPermission();
+      let granted = await smsPermissionService.hasPermission();
+      if (!granted) {
+        granted = await smsPermissionService.requestPermission();
+      }
+
       if (!granted) {
         alert("SMS permission is required to read messages in the background.");
         setBackgroundSmsEnabled(false);


### PR DESCRIPTION
## Summary
- update Settings to request `BackgroundSmsListener` permissions

## Testing
- `npm run lint`
- `npm test` *(fails: expected 3 failed suites)*

------
https://chatgpt.com/codex/tasks/task_e_686d71b5d7a08333b4a2c5fc2884250c