### PR TITLE
Update SMS permission flow

### DIFF
--- a/src/services/__tests__/SmsPermissionService.test.ts
+++ b/src/services/__tests__/SmsPermissionService.test.ts
@@ -1,0 +1,25 @@
+import { smsPermissionService } from '../SmsPermissionService';
+import { SmsReaderService } from '../SmsReaderService';
+import { loadSmsListener } from '@/lib/native/BackgroundSmsListener';
+
+jest.mock('../SmsReaderService');
+jest.mock('@/lib/native/BackgroundSmsListener');
+
+describe('SmsPermissionService.requestPermission', () => {
+  it('requests both sms reader and listener permissions', async () => {
+    (SmsReaderService.requestPermission as jest.Mock).mockResolvedValue(true);
+
+    const requestPermission = jest.fn().mockResolvedValue({ granted: true });
+    (loadSmsListener as jest.Mock).mockResolvedValue({
+      requestPermission,
+      checkPermission: jest.fn(),
+      startListening: jest.fn(),
+    });
+
+    const granted = await smsPermissionService.requestPermission();
+
+    expect(SmsReaderService.requestPermission).toHaveBeenCalled();
+    expect(requestPermission).toHaveBeenCalled();
+    expect(granted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- check permissions from both reader & listener
- request permissions for both SMS plugins
- test combined permission requests

## Testing
- `npx vitest run` *(fails: cannot install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_686d7d047ecc83339470fea013dfaf12