### PR TITLE
Enable auto-save for background SMS toggle

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -123,6 +123,9 @@ const Settings = () => {
     }
 
     setBackgroundSmsEnabled(checked);
+    updateUserPreferences({
+      sms: { ...user?.preferences?.sms, backgroundSmsEnabled: checked },
+    });
   };
 
   const handleSaveSettings = () => {
@@ -354,7 +357,7 @@ const Settings = () => {
                 Enable Background SMS Reading
               </Label>
               <p className="text-sm text-muted-foreground">
-                Read incoming SMS in the background
+                Read incoming SMS in the background. Changes save automatically.
               </p>
             </div>
             <Switch

--- a/src/pages/__tests__/SettingsBackgroundSms.test.tsx
+++ b/src/pages/__tests__/SettingsBackgroundSms.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { UserProvider, useUser } from '@/context/UserContext';
+import Settings from '../Settings';
+import { vi } from 'vitest';
+
+vi.mock('@/services/SmsPermissionService', () => ({
+  smsPermissionService: {
+    hasPermission: vi.fn().mockResolvedValue(true),
+    requestPermission: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock('@/components/FeedbackButton', () => ({
+  default: () => <div>Feedback</div>,
+}));
+
+vi.mock('@/components/Layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const StateViewer = () => {
+  const { user } = useUser();
+  const enabled = user?.preferences?.sms?.backgroundSmsEnabled;
+  return <div data-testid="sms-state">{String(enabled)}</div>;
+};
+
+describe('Settings background SMS toggle', () => {
+  it('persists preference when toggled', async () => {
+    render(
+      <UserProvider>
+        <MemoryRouter>
+          <Settings />
+          <StateViewer />
+        </MemoryRouter>
+      </UserProvider>
+    );
+
+    const toggle = screen.getByLabelText(/enable background sms reading/i);
+    expect(screen.getByTestId('sms-state')).toHaveTextContent('undefined');
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    expect(screen.getByTestId('sms-state')).toHaveTextContent('true');
+  });
+});


### PR DESCRIPTION
## Summary
- persist background SMS toggle instantly
- clarify automatic saving
- add test for SMS toggle persistence

## Testing
- `bun run test --silent` *(fails: `vitest` not found)*
- `bun run lint` *(fails: `eslint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7f3d48c48333900f6bde8e2fc6b2