### PR TITLE
Add native CSV sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,9 @@ Additional log markers are emitted to help verify the SMS workflow:
 
 Use `adb logcat | grep AIS-` while testing to see these markers.
 
+## Exporting Data
+
+On Android and iOS the **Export Data** option saves the CSV to the Documents
+directory and then opens the native Share dialog so you can send or store the
+file using other apps.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@capacitor/ios": "^7.1.0",
         "@capacitor/local-notifications": "^7.0.1",
         "@capacitor/preferences": "^7.0.1",
+        "@capacitor/share": "^7.0.1",
         "@capacitor/status-bar": "^7.0.1",
         "@hookform/resolvers": "^3.9.0",
         "@huggingface/transformers": "^3.4.2",
@@ -892,6 +893,15 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-7.0.1.tgz",
       "integrity": "sha512-XF9jOHzvoIBZLwZr/EX6aVaUO1d8Mx7TwBLQS33pYHOliCW5knT5KUkFOXNNYxh9qqODYesee9xuQIKNJpQBag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/share": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-7.0.1.tgz",
+      "integrity": "sha512-7GAtWrb2inEWohC8E7mx38qAX6D9yqPDDnUtJaZ8JRpo15jjFRS40Cx388M8h4NlBWjV5NU3qf1sHXnyOBSJ5g==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@capacitor/ios": "^7.1.0",
     "@capacitor/local-notifications": "^7.0.1",
     "@capacitor/preferences": "^7.0.1",
+    "@capacitor/share": "^7.0.1",
     "@capacitor/status-bar": "^7.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@huggingface/transformers": "^3.4.2",

--- a/src/components/settings/DataManagementSettings.tsx
+++ b/src/components/settings/DataManagementSettings.tsx
@@ -6,11 +6,12 @@ import { Download, UploadCloud, Database } from 'lucide-react';
 import { useToast } from '@/components/ui/use-toast';
 import { getStoredTransactions, storeTransactions } from '@/utils/storage-utils';
 import { convertTransactionsToCsv, parseCsvTransactions } from '@/utils/csv';
+import { exportCsvViaShare } from '@/utils/export-utils';
 
 const DataManagementSettings = () => {
   const { toast } = useToast();
   
-  const handleExportData = () => {
+  const handleExportData = async () => {
     try {
       const transactions = getStoredTransactions();
       if (!transactions.length) {
@@ -23,21 +24,33 @@ const DataManagementSettings = () => {
       }
 
       const csv = convertTransactionsToCsv(transactions);
-      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
 
-      const downloadAnchorNode = document.createElement('a');
-      downloadAnchorNode.href = url;
-      downloadAnchorNode.download = 'transactions.csv';
-      document.body.appendChild(downloadAnchorNode);
-      downloadAnchorNode.click();
-      downloadAnchorNode.remove();
-      URL.revokeObjectURL(url);
+      try {
+        const didShare = await exportCsvViaShare(csv);
+        if (!didShare) {
+          const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+          const url = URL.createObjectURL(blob);
 
-      toast({
-        title: "Export successful",
-        description: "Your data has been exported successfully.",
-      });
+          const downloadAnchorNode = document.createElement('a');
+          downloadAnchorNode.href = url;
+          downloadAnchorNode.download = 'transactions.csv';
+          document.body.appendChild(downloadAnchorNode);
+          downloadAnchorNode.click();
+          downloadAnchorNode.remove();
+          URL.revokeObjectURL(url);
+        }
+
+        toast({
+          title: "Export successful",
+          description: "Your data has been exported successfully.",
+        });
+      } catch (err) {
+        toast({
+          title: "Export failed",
+          description: "An error occurred while exporting your data.",
+          variant: "destructive",
+        });
+      }
     } catch (error) {
       toast({
         title: "Export failed",

--- a/src/utils/export-utils.ts
+++ b/src/utils/export-utils.ts
@@ -1,0 +1,38 @@
+import { Capacitor } from '@capacitor/core';
+import { Filesystem, Directory } from '@capacitor/filesystem';
+import { Share } from '@capacitor/share';
+
+/**
+ * Write the provided CSV data to the native filesystem and
+ * present the platform share dialog so users can export the file.
+ *
+ * Returns true if the export completed successfully.
+ */
+export async function exportCsvViaShare(csv: string): Promise<boolean> {
+  if (!Capacitor.isNativePlatform()) return false;
+
+  const fileName = 'transactions.csv';
+
+  try {
+    await Filesystem.writeFile({
+      path: fileName,
+      data: csv,
+      directory: Directory.Documents,
+    });
+
+    const { uri } = await Filesystem.getUri({
+      path: fileName,
+      directory: Directory.Documents,
+    });
+
+    await Share.share({
+      title: 'Export transactions',
+      url: uri,
+    });
+
+    return true;
+  } catch (err) {
+    console.error('[exportCsvViaShare] Failed to export file:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- install `@capacitor/share`
- add helper to write CSV and invoke Share dialog
- use helper when exporting data in Settings screen
- use helper when exporting data in DataManagementSettings
- document that mobile export uses native Share dialog

## Testing
- `npm run lint` *(fails: 287 problems)*
- `npm run test` *(fails: 3 failed | 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686d850922288333a61ee53fdf49a044