### PR TITLE
Switch App routing to React Router data API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { BrowserRouter, Route, Routes, useNavigate, useLocation } from 'react-router-dom';
+import {
+  Route,
+  useNavigate,
+  useLocation,
+  createBrowserRouter,
+  RouterProvider,
+  createRoutesFromElements,
+  Outlet,
+} from 'react-router-dom';
 import { ThemeProvider } from "@/components/theme-provider";
 import Home from './pages/Home';
 import Transactions from './pages/Transactions';
@@ -231,40 +239,7 @@ function AppWrapper() {
 
   return (
     <>
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/home" element={<Home />} />
-      <Route path="/transactions" element={<Transactions />} />
-      <Route path="/analytics" element={<Analytics />} />
-      <Route path="/profile" element={<Profile />} />
-      <Route path="/onboarding" element={<Onboarding />} />
-      <Route path="/import-transactions" element={<ImportTransactions />} />
-      <Route path="/import-transactions-ner" element={<ImportTransactionsNER />} />
-      <Route path="/edit-transaction" element={<EditTransaction />} />
-      <Route path="/edit-transaction/:id" element={<EditTransaction />} />
-      <Route path="/train-model" element={<TrainModel />} />
-      <Route path="/test-analytics" element={<TestFirebaseAnalytics />} />
-      <Route path="/build-template" element={<BuildTemplate />} />
-      <Route path="/keyword-bank" element={<KeywordBankManager />} />
-      {process.env.NODE_ENV === 'development' && (
-        <>
-          <Route path="/dev/template-health" element={<TemplateHealthDashboard />} />
-          <Route path="/dev/template-failures" element={<TemplateFailureLog />} />
-        </>
-      )}
-      <Route path="/custom-parsing-rules" element={<CustomParsingRules />} />
-      <Route path="/settings" element={<Settings />} />
-      <Route path="/process-sms" element={<ProcessSmsMessages />} />
-      <Route path="/sms/process-vendors" element={<ProcessVendors />} />
-      <Route path="/sms/vendors" element={<VendorCategorization />} />
-      <Route path="/vendor-mapping" element={<VendorMapping />} />
-      <Route path="/review-sms-transactions" element={<ReviewSmsTransactions />} />
-      <Route path="/budget/accounts" element={<AccountsPage />} />
-      <Route path="/budget/set" element={<SetBudgetPage />} />
-      <Route path="/budget/report" element={<BudgetReportPage />} />
-      <Route path="/budget/insights" element={<BudgetInsightsPage />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <Outlet />
     <SmartPasteReviewQueueModal
       open={queueOpen}
       messages={queuedMessages}
@@ -278,18 +253,55 @@ function AppWrapper() {
   );
 }
 
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route path="/" element={<AppWrapper />}>
+      <Route index element={<Home />} />
+      <Route path="home" element={<Home />} />
+      <Route path="transactions" element={<Transactions />} />
+      <Route path="analytics" element={<Analytics />} />
+      <Route path="profile" element={<Profile />} />
+      <Route path="onboarding" element={<Onboarding />} />
+      <Route path="import-transactions" element={<ImportTransactions />} />
+      <Route path="import-transactions-ner" element={<ImportTransactionsNER />} />
+      <Route path="edit-transaction" element={<EditTransaction />} />
+      <Route path="edit-transaction/:id" element={<EditTransaction />} />
+      <Route path="train-model" element={<TrainModel />} />
+      <Route path="test-analytics" element={<TestFirebaseAnalytics />} />
+      <Route path="build-template" element={<BuildTemplate />} />
+      <Route path="keyword-bank" element={<KeywordBankManager />} />
+      {process.env.NODE_ENV === 'development' && (
+        <>
+          <Route path="dev/template-health" element={<TemplateHealthDashboard />} />
+          <Route path="dev/template-failures" element={<TemplateFailureLog />} />
+        </>
+      )}
+      <Route path="custom-parsing-rules" element={<CustomParsingRules />} />
+      <Route path="settings" element={<Settings />} />
+      <Route path="process-sms" element={<ProcessSmsMessages />} />
+      <Route path="sms/process-vendors" element={<ProcessVendors />} />
+      <Route path="sms/vendors" element={<VendorCategorization />} />
+      <Route path="vendor-mapping" element={<VendorMapping />} />
+      <Route path="review-sms-transactions" element={<ReviewSmsTransactions />} />
+      <Route path="budget/accounts" element={<AccountsPage />} />
+      <Route path="budget/set" element={<SetBudgetPage />} />
+      <Route path="budget/report" element={<BudgetReportPage />} />
+      <Route path="budget/insights" element={<BudgetInsightsPage />} />
+      <Route path="*" element={<NotFound />} />
+    </Route>
+  )
+);
+
 function App() {
   return (
-    <BrowserRouter>
-      <ThemeProvider defaultTheme="light" attribute="class">
-        <UserProvider>
-          <TransactionProvider>
-            <AppWrapper />
-            <Toaster />
-          </TransactionProvider>
-        </UserProvider>
-      </ThemeProvider>
-    </BrowserRouter>
+    <ThemeProvider defaultTheme="light" attribute="class">
+      <UserProvider>
+        <TransactionProvider>
+          <RouterProvider router={router} />
+          <Toaster />
+        </TransactionProvider>
+      </UserProvider>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- migrate `App.tsx` from `BrowserRouter` to the data router
- render routes using `createBrowserRouter` and `RouterProvider`
- expose `<Outlet />` from `AppWrapper` for nested routing

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e69008480833380c138e280839d41