### PR TITLE
Fix notification toggle persistence

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -68,11 +68,21 @@ const Settings = () => {
   );
 
   useEffect(() => {
-    if (typeof Notification !== 'undefined') {
-      setNotificationsAllowed(Notification.permission === "granted");
-    } else {
-      setNotificationsAllowed(false);
-    }
+    const checkPermissions = async () => {
+      const platform = Capacitor.getPlatform();
+      if (platform === 'web' && typeof Notification !== 'undefined') {
+        setNotificationsAllowed(Notification.permission === 'granted');
+      } else {
+        try {
+          const status = await LocalNotifications.checkPermissions();
+          setNotificationsAllowed(status.display === 'granted');
+        } catch {
+          setNotificationsAllowed(false);
+        }
+      }
+    };
+
+    checkPermissions();
   }, []);
 
   // State for form values


### PR DESCRIPTION
## Summary
- ensure Settings page re-checks notification permission on app start

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: onnxruntime-node ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686e7f87ee3c8333a81edd53eb38a8af