### PR TITLE
Fix CSV import errors from newline data

### DIFF
--- a/src/utils/__tests__/csv.test.ts
+++ b/src/utils/__tests__/csv.test.ts
@@ -42,4 +42,23 @@ describe('CSV utilities', () => {
     expect(parsed[0].id).toBe('1');
     expect(parsed[0].title).toBe('Item');
   });
+
+  it('handles newline characters in fields', () => {
+    const txns: Transaction[] = [
+      {
+        id: '3',
+        title: 'Note with newline',
+        amount: 10,
+        category: 'Misc',
+        date: '2024-07-01',
+        type: 'expense',
+        source: 'manual',
+        notes: 'line1\nline2',
+      },
+    ];
+
+    const csv = convertTransactionsToCsv(txns);
+    const parsed = parseCsvTransactions(csv);
+    expect(parsed).toEqual(txns);
+  });
 });


### PR DESCRIPTION
## Summary
- handle newline characters when exporting transactions to CSV
- add robust CSV parsing that supports quoted newlines
- test CSV parsing with newline data

## Testing
- `npx vitest run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8407d52483339de82ceca475c2a9