### PR TITLE
Add permission callback to SmsReaderPlugin

### DIFF
--- a/capacitor-sms-reader/android/src/main/java/com/xpensia/plugins/smsreader/SmsReaderPlugin.java
+++ b/capacitor-sms-reader/android/src/main/java/com/xpensia/plugins/smsreader/SmsReaderPlugin.java
@@ -14,6 +14,8 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
+import com.getcapacitor.annotation.PermissionCallback;
+import com.getcapacitor.PermissionState;
 
 import org.json.JSONException;
 
@@ -158,5 +160,13 @@ public class SmsReaderPlugin extends Plugin {
         JSObject ret = new JSObject();
         ret.put("granted", true);
         savedCall.resolve(ret);
+    }
+
+    @PermissionCallback
+    private void permissionCallback(PluginCall call) {
+        PermissionState state = getPermissionState("read_sms");
+        JSObject ret = new JSObject();
+        ret.put("granted", state == PermissionState.GRANTED);
+        call.resolve(ret);
     }
 }


### PR DESCRIPTION
## Summary
- implement `permissionCallback` for `SmsReaderPlugin`

## Testing
- `npm run verify:android` *(fails: `./gradlew` not found)*
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e89bab6b48333bc258045bdd435c0