### PR TITLE
Add storage sync for transactions

### DIFF
--- a/src/context/TransactionContext.tsx
+++ b/src/context/TransactionContext.tsx
@@ -26,6 +26,20 @@ export const TransactionProvider: React.FC<{ children: ReactNode }> = ({ childre
     setTransactions(storedTransactions);
   }, []);
 
+  // Listen for storage changes from other tabs or manual dispatch
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === 'xpensia_transactions') {
+        setTransactions(getStoredTransactions());
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
   const addTransactions = (newTransactions: Transaction[]) => {
     // Ensure all transactions have required fields
     const validTransactions = newTransactions.map(transaction => ({

--- a/src/utils/storage-utils.ts
+++ b/src/utils/storage-utils.ts
@@ -87,6 +87,14 @@ export const getStoredTransactions = (): Transaction[] => {
 
 export const storeTransactions = (transactions: Transaction[]): void => {
   setInStorage(TRANSACTIONS_STORAGE_KEY, transactions);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: TRANSACTIONS_STORAGE_KEY,
+        newValue: JSON.stringify(transactions)
+      })
+    );
+  }
 };
 
 export const saveStructureTemplate = (template: StructureTemplateEntry) => {
@@ -134,6 +142,14 @@ export function updateTransaction(txn: Transaction) {
   const existing = JSON.parse(localStorage.getItem('xpensia_transactions') || '[]');
   const updated = existing.map((t: Transaction) => t.id === txn.id ? txn : t);
   localStorage.setItem('xpensia_transactions', JSON.stringify(updated));
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: TRANSACTIONS_STORAGE_KEY,
+        newValue: JSON.stringify(updated)
+      })
+    );
+  }
 }
 
 export function learnFromTransaction(


### PR DESCRIPTION
## Summary
- listen for storage events in TransactionContext
- dispatch a storage event whenever transactions are written

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee0c3ab9c8333bf82d7af67726d5b