### PR TITLE
Add page-level ErrorBoundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import SetBudgetPage from './pages/budget/SetBudgetPage';
 import BudgetReportPage from './pages/budget/BudgetReportPage';
 import BudgetInsightsPage from './pages/budget/BudgetInsightsPage';
 import ScrollToTop from './components/layout/ScrollToTop';
+import ErrorBoundary from './components/ErrorBoundary';
 
 
 import { StatusBar, Style } from '@capacitor/status-bar';
@@ -311,10 +312,38 @@ function AppRoutes() {
     <>
       <AppWrapper />
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/home" element={<Home />} />
-        <Route path="/transactions" element={<Transactions />} />
-        <Route path="/analytics" element={<Analytics />} />
+        <Route
+          path="/"
+          element={
+            <ErrorBoundary name="Home Page">
+              <Home />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/home"
+          element={
+            <ErrorBoundary name="Home Page">
+              <Home />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/transactions"
+          element={
+            <ErrorBoundary name="Transactions Page">
+              <Transactions />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/analytics"
+          element={
+            <ErrorBoundary name="Analytics Page">
+              <Analytics />
+            </ErrorBoundary>
+          }
+        />
         <Route path="/profile" element={<Profile />} />
         <Route path="/onboarding" element={<Onboarding />} />
         <Route path="/import-transactions" element={<ImportTransactions />} />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  name?: string;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(`Error in ${this.props.name || 'component'}:`, error, info);
+  }
+
+  handleRetry = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-center space-y-2">
+          <p className="text-destructive">
+            {this.state.error?.message || 'Something went wrong.'}
+          </p>
+          <Button variant="outline" onClick={this.handleRetry}>
+            Retry
+          </Button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- add new `ErrorBoundary` component for pages
- wrap Home, Transactions and Analytics routes with error boundary fallback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687136f40e408333adb396aafaf2627d