### PR TITLE
Add saving indicator for transaction forms

### DIFF
--- a/src/pages/AddTransaction.tsx
+++ b/src/pages/AddTransaction.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import Layout from '@/components/Layout';
@@ -14,26 +14,34 @@ import { useLearningEngine } from '@/hooks/useLearningEngine';
 import { saveTransactionWithLearning } from '@/lib/smart-paste-engine/saveTransactionWithLearning';
 import { Transaction } from '@/types/transaction';
 import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { IonLoading } from '@ionic/react';
 
 const AddTransaction = () => {
   const navigate = useNavigate();
   const { addTransaction, updateTransaction } = useTransactions();
   const { learnFromTransaction } = useLearningEngine();
+  const [saving, setSaving] = useState(false);
 
   const handleSave = (txn: Transaction) => {
-    saveTransactionWithLearning(txn, {
-      isNew: true,
-      addTransaction,
-      updateTransaction,
-      learnFromTransaction,
-      navigateBack: () => navigate(-1),
-      combineToasts: true,
-    });
-    FirebaseAnalytics.logEvent({ name: 'add_transaction' });
+    setSaving(true);
+    try {
+      saveTransactionWithLearning(txn, {
+        isNew: true,
+        addTransaction,
+        updateTransaction,
+        learnFromTransaction,
+        navigateBack: () => navigate(-1),
+        combineToasts: true,
+      });
+      FirebaseAnalytics.logEvent({ name: 'add_transaction' });
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
     <Layout showBack withPadding={false} fullWidth>
+      <IonLoading isOpen={saving} message="Saving..." />
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -16,6 +16,7 @@ import SmartPasteSummary from '@/components/SmartPasteSummary';
 import { LearnedEntry } from '@/types/learning';
 import { saveTransactionWithLearning } from '@/lib/smart-paste-engine/saveTransactionWithLearning';
 import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { IonLoading } from '@ionic/react';
 
 const EditTransaction = () => {
   const location = useLocation();
@@ -23,6 +24,7 @@ const EditTransaction = () => {
   const { addTransaction, updateTransaction } = useTransactions();
   const { toast } = useToast();
   const { learnFromTransaction } = useLearningEngine();
+  const [saving, setSaving] = useState(false);
 
   const [matchDetails, setMatchDetails] = useState<{
     entry: LearnedEntry | null;
@@ -40,17 +42,22 @@ const EditTransaction = () => {
   const isNewTransaction = !transaction;
 
   const handleSave = (editedTransaction: Transaction) => {
-    saveTransactionWithLearning(editedTransaction, {
-      rawMessage,
-      isNew: isNewTransaction,
-      senderHint,
-      addTransaction,
-      updateTransaction,
-      learnFromTransaction,
-      navigateBack: () => navigate(-1),
-      combineToasts: true,
-    });
-    FirebaseAnalytics.logEvent({ name: 'edit_transaction' });
+    setSaving(true);
+    try {
+      saveTransactionWithLearning(editedTransaction, {
+        rawMessage,
+        isNew: isNewTransaction,
+        senderHint,
+        addTransaction,
+        updateTransaction,
+        learnFromTransaction,
+        navigateBack: () => navigate(-1),
+        combineToasts: true,
+      });
+      FirebaseAnalytics.logEvent({ name: 'edit_transaction' });
+    } finally {
+      setSaving(false);
+    }
   };
 
   useEffect(() => {
@@ -73,6 +80,7 @@ const EditTransaction = () => {
 
   return (
     <Layout showBack withPadding={false} fullWidth>
+      <IonLoading isOpen={saving} message="Saving..." />
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}


### PR DESCRIPTION
## Summary
- add a `saving` state to AddTransaction and EditTransaction pages
- show an `IonLoading` overlay while saving

## Testing
- `npm install` *(fails: ENETUNREACH github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68717a8bd67c8333981870fec54bb7d6