### PR TITLE
Add loading state to profile image hook

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -31,12 +31,13 @@ import {
 } from '@/components/ui/alert-dialog';
 
 import { useProfileImage } from '@/hooks/useProfileImage';
+import { IonLoading } from '@ionic/react';
 import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
 
 const Profile = () => {
   const { user, updateUser } = useUser();
   const { toast } = useToast();
-  const { image, takeOrSelectPhoto } = useProfileImage();
+  const { image, takeOrSelectPhoto, loading } = useProfileImage();
   const [isEditing, setIsEditing] = useState(false);
   const [editFormData, setEditFormData] = useState({
     fullName: user?.fullName || '',
@@ -85,6 +86,7 @@ const Profile = () => {
 
   return (
     <Layout>
+      <IonLoading isOpen={loading} message="Loading image..." />
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}


### PR DESCRIPTION
## Summary
- add loading state management to `useProfileImage`
- display spinner when profile image is being loaded or saved

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717be58b20833398090c4066f65bbc