### PR TITLE
Map technical errors to friendly messages

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
+import { getFriendlyMessage } from '@/utils/errorMapper';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -34,7 +35,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       return (
         <div className="p-4 text-center space-y-2">
           <p className="text-destructive">
-            {this.state.error?.message || 'Something went wrong.'}
+            {this.state.error ? getFriendlyMessage(this.state.error) : 'Something went wrong.'}
           </p>
           <Button variant="outline" onClick={this.handleRetry}>
             Retry
@@ -47,3 +48,4 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 }
 
 export default ErrorBoundary;
+

--- a/src/components/forms/ErrorRecoveryFlow.tsx
+++ b/src/components/forms/ErrorRecoveryFlow.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { AlertTriangle, RotateCcw, FileText, HelpCircle } from 'lucide-react';
 import { getBrandMessage } from '@/constants/brandGuidelines';
+import { getFriendlyMessage } from '@/utils/errorMapper';
 
 interface ErrorRecoveryFlowProps {
   error: Error;
@@ -52,7 +53,8 @@ const ErrorRecoveryFlow: React.FC<ErrorRecoveryFlowProps> = ({
     ];
   };
 
-  const errorSuggestions = getErrorSuggestions(error.message);
+  const friendlyMessage = getFriendlyMessage(error);
+  const errorSuggestions = getErrorSuggestions(friendlyMessage);
 
   return (
     <Card className="w-full border-destructive/20">
@@ -126,7 +128,7 @@ const ErrorRecoveryFlow: React.FC<ErrorRecoveryFlowProps> = ({
         {showDetails && (
           <div className="space-y-3 pt-3 border-t">
             <div className="bg-muted p-3 rounded-md text-xs font-mono">
-              <strong>Error:</strong> {error.message}
+              <strong>Error:</strong> {friendlyMessage}
               {error.stack && (
                 <>
                   <br />

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -5,6 +5,7 @@ import { RefreshCw, Info } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { handleError } from "@/utils/error-utils";
 import { ErrorType, ErrorSeverity } from "@/types/error";
+import { getFriendlyMessage } from "@/utils/errorMapper";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -49,9 +50,10 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     }
     
     // Use our global error handler
+    const friendly = getFriendlyMessage(error);
     handleError({
       type: ErrorType.UNKNOWN,
-      message: `Error in ${this.props.name || 'component'}: ${error.message}`,
+      message: `Error in ${this.props.name || 'component'}: ${friendly}`,
       severity: ErrorSeverity.ERROR,
       details: {
         componentStack: errorInfo.componentStack,
@@ -64,7 +66,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       toast({
         variant: 'destructive',
         title: `Error: ${this.props.name || 'Component'} failed to load`,
-        description: `${error.message || 'An unexpected error occurred.'} Please try again using the Retry button.`
+        description: `${friendly} Please try again using the Retry button.`
       });
     }
   }

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 import { useToast } from '@/components/ui/use-toast';
+import { getFriendlyMessage } from '@/utils/errorMapper';
 
 interface UseAutoSaveOptions {
   delay?: number;
@@ -39,7 +40,7 @@ export const useAutoSave = (
       setTimeout(() => setSaveStatus('idle'), 2000);
     } catch (error) {
       setSaveStatus('error');
-      const errorMessage = error instanceof Error ? error.message : 'Failed to save';
+      const errorMessage = getFriendlyMessage(error);
       
       if (onError) {
         onError(error as Error);

--- a/src/lib/supabase-auth.ts
+++ b/src/lib/supabase-auth.ts
@@ -2,6 +2,7 @@ import { safeStorage } from "@/utils/safe-storage";
 import { supabase } from './supabase';
 import { ErrorType, AppError, ErrorSeverity } from '@/types/error';
 import { handleError, createError } from '@/utils/error-utils';
+import { getFriendlyMessage } from '@/utils/errorMapper';
 import { ENABLE_SUPABASE_AUTH } from './env';
 
 // Session timeout in milliseconds (30 minutes instead of 15)
@@ -74,8 +75,8 @@ export const startPhoneVerificationWithSupabase = async (phoneNumber: string): P
       return {
         success: false,
         error: createError(
-          ErrorType.AUTH, 
-          error.message || 'Failed to send verification code',
+          ErrorType.AUTH,
+          getFriendlyMessage(error) || 'Failed to send verification code',
           { phoneNumber, statusCode: error.status },
           error,
           ErrorSeverity.ERROR
@@ -230,8 +231,8 @@ export const confirmPhoneVerificationWithSupabase = async (code: string): Promis
       return {
         success: false,
         error: createError(
-          ErrorType.AUTH, 
-          `${error.message || 'Invalid verification code'}. ${attemptsLeft} attempts remaining.`,
+          ErrorType.AUTH,
+          `${getFriendlyMessage(error) || 'Invalid verification code'}. ${attemptsLeft} attempts remaining.`,
           { attemptsLeft, attempts: verificationState.attempts, phoneNumber: verificationState.phoneNumber },
           error
         )
@@ -473,3 +474,4 @@ export const getMaxVerificationAttempts = (): number => {
 export const getVerificationAttemptsRemaining = (): number => {
   return MAX_VERIFICATION_ATTEMPTS - verificationState.attempts;
 };
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css'
 import './styles/app.css'
 
 import { handleError } from './utils/error-utils'
+import { getFriendlyMessage } from './utils/errorMapper'
 import { ErrorType, ErrorSeverity } from './types/error'
 import { initializeXpensiaStorageDefaults } from './lib/smart-paste-engine/initializeXpensiaStorageDefaults'
 import { initializeCapacitor } from './lib/capacitor-init'
@@ -18,7 +19,7 @@ function setupGlobalErrorHandlers() {
   window.addEventListener('unhandledrejection', (event) => {
     handleError({
       type: ErrorType.UNKNOWN,
-      message: event.reason?.message || 'Unhandled Promise Rejection',
+      message: getFriendlyMessage(event.reason) || 'Unhandled Promise Rejection',
       severity: ErrorSeverity.ERROR,
       details: { source: 'unhandledrejection', stack: event.reason?.stack },
       originalError: event.reason
@@ -29,7 +30,7 @@ function setupGlobalErrorHandlers() {
   window.addEventListener('error', (event) => {
     handleError({
       type: ErrorType.UNKNOWN,
-      message: event.error?.message || event.message || 'Uncaught Error',
+      message: getFriendlyMessage(event.error) || 'Uncaught Error',
       severity: ErrorSeverity.CRITICAL,
       details: {
         source: 'window.onerror',

--- a/src/utils/errorMapper.ts
+++ b/src/utils/errorMapper.ts
@@ -1,0 +1,10 @@
+export const getFriendlyMessage = (err: unknown): string => {
+  const message = typeof err === 'string' ? err : (err as any)?.message ?? '';
+  if (message.toLowerCase().includes('permission')) {
+    return 'SMS permission is required to continue.';
+  }
+  if (message.toLowerCase().includes('storage')) {
+    return 'There was a problem saving your data. Please try again.';
+  }
+  return 'Something went wrong. Please try again later.';
+};


### PR DESCRIPTION
## Summary
- provide `getFriendlyMessage` helper for mapping technical errors to human-friendly text
- surface friendly errors in AutoSave hook and both error boundaries
- show mapped messages in ErrorRecoveryFlow and Supabase auth flows
- use mapper in global error handlers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68717d0a6c8c8333a9016409b8ae38a0