### PR TITLE
Add sample data reset

### DIFF
--- a/src/components/settings/DataManagementSettings.tsx
+++ b/src/components/settings/DataManagementSettings.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Download, UploadCloud, Database } from 'lucide-react';
+import { Download, UploadCloud, Database, Trash2 } from 'lucide-react';
+import { demoTransactionService } from '@/services/DemoTransactionService';
 import { useToast } from '@/components/ui/use-toast';
 import { getStoredTransactions, storeTransactions } from '@/utils/storage-utils';
 import { convertTransactionsToCsv, parseCsvTransactions } from '@/utils/csv';
@@ -97,6 +98,27 @@ const DataManagementSettings = () => {
     
     fileInput.click();
   };
+
+  const handleClearSampleData = () => {
+    const confirmClear = window.confirm(
+      'Are you sure you want to clear the sample data?'
+    );
+    if (!confirmClear) return;
+
+    try {
+      demoTransactionService.clearDemoTransactions();
+      toast({
+        title: 'Sample data cleared',
+        description: 'Demo transactions have been removed.',
+      });
+      setTimeout(() => window.location.reload(), 1500);
+    } catch (error) {
+      toast({
+        title: 'Failed to clear sample data',
+        variant: 'destructive',
+      });
+    }
+  };
   
   return (
     <Card className="border border-border shadow-sm">
@@ -128,6 +150,17 @@ const DataManagementSettings = () => {
             <Button variant="outline" onClick={handleImportData} className="gap-2">
               <UploadCloud size={16} />
               Import
+            </Button>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium">Clear Sample Data</p>
+              <p className="text-sm text-muted-foreground">Remove seeded demo transactions</p>
+            </div>
+            <Button variant="outline" onClick={handleClearSampleData} className="gap-2 text-destructive">
+              <Trash2 size={16} />
+              Clear Sample Data
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `demoTransactionService.clearDemoTransactions` button to Data management settings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723268f8408333808c5ad859fb7fd5