### PR TITLE
Fix NaN validation for stored transactions

### DIFF
--- a/src/utils/storage-utils-fixes.ts
+++ b/src/utils/storage-utils-fixes.ts
@@ -10,7 +10,10 @@ export const validateTransactionForStorage = (transaction: any): Transaction => 
     // Required fields with defaults
     id: transaction.id || '',
     title: transaction.title || 'Untitled Transaction',
-    amount: typeof transaction.amount === 'number' ? transaction.amount : 0,
+    amount:
+      typeof transaction.amount === 'number' && !isNaN(transaction.amount)
+        ? transaction.amount
+        : 0,
     category: transaction.category || 'Uncategorized',
     date: transaction.date || new Date().toISOString(),
     type: transaction.type === 'income' || transaction.type === 'expense' || transaction.type === 'transfer' 


### PR DESCRIPTION
## Summary
- ensure transaction amounts are numeric before persisting

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687296cf0cc4833380c3f38cc1c0a003