### PR TITLE
sync background sms toggle with permission

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -149,6 +149,17 @@ const Settings = () => {
       if (granted) {
         setBackgroundSmsEnabled(true);
         setBaselineBackgroundSmsEnabled(true);
+        if (!user?.preferences?.sms?.backgroundSmsEnabled) {
+          updateUser({
+            preferences: {
+              ...user?.preferences,
+              sms: {
+                ...user?.preferences?.sms,
+                backgroundSmsEnabled: true,
+              },
+            },
+          });
+        }
       }
     };
 
@@ -193,6 +204,16 @@ const Settings = () => {
         setBackgroundSmsEnabled(false);
         return;
       }
+      // Persist preference when permission is granted
+      updateUser({
+        preferences: {
+          ...user?.preferences,
+          sms: {
+            ...user?.preferences?.sms,
+            backgroundSmsEnabled: true,
+          },
+        },
+      });
     }
 
     setBackgroundSmsEnabled(checked);

--- a/src/pages/__tests__/SettingsBackgroundSms.test.tsx
+++ b/src/pages/__tests__/SettingsBackgroundSms.test.tsx
@@ -45,4 +45,18 @@ describe('Settings background SMS toggle', () => {
 
     expect(screen.getByTestId('sms-state')).toHaveTextContent('true');
   });
+
+  it('reflects existing permission on mount', async () => {
+    render(
+      <UserProvider>
+        <BrowserRouter>
+          <Settings />
+          <StateViewer />
+        </BrowserRouter>
+      </UserProvider>
+    );
+
+    expect(await screen.findByLabelText(/enable background sms reading/i)).toBeChecked();
+    expect(screen.getByTestId('sms-state')).toHaveTextContent('true');
+  });
 });


### PR DESCRIPTION
## Summary
- persist user preference when background SMS permission is granted
- update preference state if permission was granted previously
- test Settings page for initial permission state

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729d11defc83338d410f2621b95c15