### PR TITLE
Fix onboarding scrolling issue on mobile

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -16,6 +16,11 @@ interface LayoutProps {
   showHeader?: boolean;
   fullWidth?: boolean;
   showBack?: boolean;
+  /**
+   * Apply safe area padding to the top and bottom of the layout.
+   * Useful for pages that need to manage safe areas themselves.
+   */
+  safeAreaPadding?: boolean;
 }
 
 const Layout = ({
@@ -26,6 +31,7 @@ const Layout = ({
   showHeader = true,
   fullWidth = false,
   showBack = false,
+  safeAreaPadding = true,
 }: LayoutProps) => {
   const isMobile = useIsMobile();
   const { isMobile: isResponsiveMobile } = useResponsive();
@@ -36,7 +42,7 @@ const Layout = ({
       className={cn(
         "min-h-screen flex flex-col",
         showHeader && "pt-[var(--header-height)]",
-        !showHeader && "pt-[var(--safe-area-top)]",
+        !showHeader && safeAreaPadding && "pt-[var(--safe-area-top)]",
         className
       )}
     >
@@ -54,7 +60,7 @@ const Layout = ({
               "h-full",
               withPadding && "p-page",
               !fullWidth && "max-w-[var(--content-max-width)] mx-auto",
-              isResponsiveMobile && "pb-safe-bottom"
+              isResponsiveMobile && safeAreaPadding && "pb-safe-bottom"
             )}
           >
             <AnimatePresence mode="wait" initial={false}>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -13,7 +13,14 @@ const Onboarding = () => {
   };
 
   return (
-    <Layout hideNavigation showHeader={false} withPadding={false} fullWidth className="w-full overflow-hidden">
+    <Layout
+      hideNavigation
+      showHeader={false}
+      withPadding={false}
+      fullWidth
+      className="w-full overflow-hidden"
+      safeAreaPadding={false}
+    >
       <OnboardingSlides onComplete={handleComplete} />
     </Layout>
 


### PR DESCRIPTION
## Summary
- add optional `safeAreaPadding` prop to `Layout`
- disable safe area padding on onboarding page to avoid vertical scrolling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f54c4b288333aa81e03bafe886a7