### PR TITLE
Add delete confirmation dialog

### DIFF
--- a/src/components/transactions/__tests__/TransactionList.test.tsx
+++ b/src/components/transactions/__tests__/TransactionList.test.tsx
@@ -47,6 +47,10 @@ describe('TransactionList', () => {
     expect(handleEdit).toHaveBeenCalledWith(transaction);
 
     fireEvent.click(buttons[1]);
+    expect(
+      screen.getByText('Are you sure you want to delete this transaction?')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
     expect(handleDelete).toHaveBeenCalledWith(transaction.id);
   });
 


### PR DESCRIPTION
## Summary
- add Trash2 delete dialog logic in `TransactionList`
- update tests for new dialog

## Testing
- `npx vitest run` *(fails: Cannot find package 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_687416763cb0833381899c300bef68dd