### PR TITLE
Fix clearing demo transactions

### DIFF
--- a/src/services/DemoTransactionService.ts
+++ b/src/services/DemoTransactionService.ts
@@ -95,7 +95,9 @@ class DemoTransactionService {
     const existing = getStoredTransactions();
     const filtered = existing.filter(t => !t.isSample);
     storeTransactions(filtered);
-    safeStorage.removeItem(INIT_FLAG_KEY);
+    // Maintain the initialization flag so that demo data is not reseeded
+    // when the application reloads after clearing sample transactions.
+    safeStorage.setItem(INIT_FLAG_KEY, 'true');
   }
 }
 


### PR DESCRIPTION
## Summary
- stop reseeding demo transactions after clearing sample data

## Testing
- `npm install` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68741d6cc6248333905746631aabb542