### PR TITLE
Improve Firebase analytics checks

### DIFF
--- a/src/components/NERSmartPaste.tsx
+++ b/src/components/NERSmartPaste.tsx
@@ -10,7 +10,7 @@ import DetectedTransactionCard from './smart-paste/DetectedTransactionCard';
 import ErrorAlert from './smart-paste/ErrorAlert';
 import NoTransactionMessage from './smart-paste/NoTransactionMessage';
 import { extractTransactionEntities } from '@/services/MLTransactionParser';
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 
 // Simplified SmartPaste component that only uses the NER model to
 // extract transaction entities. The learning engine will still learn
@@ -64,7 +64,7 @@ const handleSubmit = async (e: React.FormEvent) => {
   setError(null);
   setConfidence(null);
   setMatchOrigin(null);
-  FirebaseAnalytics.logEvent({ name: 'smart_paste_sms' });
+  logAnalyticsEvent('smart_paste_sms');
 
   try {
     const parsed = await extractTransactionEntities(text);
@@ -162,7 +162,7 @@ const handleSubmit = async (e: React.FormEvent) => {
       );
     }
 
-    FirebaseAnalytics.logEvent({ name: 'smart_paste_save' });
+    logAnalyticsEvent('smart_paste_save');
 
     toast({
       title: "Transaction added",

--- a/src/components/SmartPaste.tsx
+++ b/src/components/SmartPaste.tsx
@@ -14,7 +14,7 @@ import { parseAndInferTransaction } from '@/lib/smart-paste-engine/parseAndInfer
 import { getTemplateFailureCount } from '@/lib/smart-paste-engine/templateUtils';
 import { useNavigate } from 'react-router-dom';
 import { isFinancialTransactionMessage } from '@/lib/smart-paste-engine/messageFilter';
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 
 
 
@@ -106,7 +106,7 @@ const handleSubmit = async (e: React.FormEvent) => {
   setError(null);
   setConfidence(null);
   setMatchOrigin(null);
-  FirebaseAnalytics.logEvent({ name: 'smart_paste_sms' });
+  logAnalyticsEvent('smart_paste_sms');
 
   try {
     const {
@@ -227,7 +227,7 @@ const handleSubmit = async (e: React.FormEvent) => {
       );
     }
 
-    FirebaseAnalytics.logEvent({ name: 'smart_paste_save' });
+    logAnalyticsEvent('smart_paste_save');
 
     toast({
       title: "Transaction added",

--- a/src/hooks/useProfileImage.ts
+++ b/src/hooks/useProfileImage.ts
@@ -2,7 +2,7 @@ import { safeStorage } from "@/utils/safe-storage";
 import { useEffect, useState } from 'react';
 import { Camera, CameraResultType, CameraSource } from '@capacitor/camera';
 import { Filesystem, Directory } from '@capacitor/filesystem';
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 
 const PROFILE_IMAGE_KEY = 'profileImagePath';
 
@@ -35,7 +35,7 @@ export function useProfileImage() {
 
       safeStorage.setItem(PROFILE_IMAGE_KEY, fileName);
       setImage(`data:image/jpeg;base64,${base64Data}`);
-      FirebaseAnalytics.logEvent({ name: 'photo_added' });
+      logAnalyticsEvent('photo_added');
     } finally {
       setLoading(false);
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { demoTransactionService } from './services/DemoTransactionService'
 
 import { Capacitor } from '@capacitor/core'
 import { FirebaseAnalytics } from '@capacitor-firebase/analytics'
+import { logAnalyticsEvent } from '@/utils/firebase-analytics'
 import { Device } from '@capacitor/device'
 
 
@@ -93,7 +94,7 @@ if (Capacitor.isNativePlatform()) {
       await FirebaseAnalytics.enable()
       const { identifier } = await Device.getId()
       await FirebaseAnalytics.setUserId({ userId: identifier })
-      await FirebaseAnalytics.logEvent({ name: 'app_launch' })
+      await logAnalyticsEvent('app_launch')
     } catch (err) {
       if (import.meta.env.MODE === 'development') {
         console.warn('[FirebaseAnalytics] error:', err)

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -15,7 +15,7 @@ import {
   CardTitle
 } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 import {
   BarChart,
   Bar,
@@ -45,7 +45,7 @@ const Analytics: React.FC = () => {
   const { transactions } = useTransactions();
 
   useEffect(() => {
-    FirebaseAnalytics.logEvent({ name: 'view_analytics' });
+    logAnalyticsEvent('view_analytics');
   }, []);
 
   type Range = '' | 'day' | 'week' | 'month' | 'year' | 'custom';

--- a/src/pages/EditTransaction.tsx
+++ b/src/pages/EditTransaction.tsx
@@ -15,7 +15,7 @@ import { useLearningEngine } from '@/hooks/useLearningEngine';
 import SmartPasteSummary from '@/components/SmartPasteSummary';
 import { LearnedEntry } from '@/types/learning';
 import { saveTransactionWithLearning } from '@/lib/smart-paste-engine/saveTransactionWithLearning';
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 import { IonLoading } from '@ionic/react';
 
 const EditTransaction = () => {
@@ -54,7 +54,7 @@ const EditTransaction = () => {
         navigateBack: () => navigate(-1),
         combineToasts: true,
       });
-      FirebaseAnalytics.logEvent({ name: 'edit_transaction' });
+      logAnalyticsEvent('edit_transaction');
     } finally {
       setSaving(false);
     }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -32,7 +32,7 @@ import {
 
 import { useProfileImage } from '@/hooks/useProfileImage';
 import { IonLoading } from '@ionic/react';
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 
 const Profile = () => {
   const { user, updateUser } = useUser();
@@ -64,7 +64,7 @@ const Profile = () => {
       phone: editFormData.phone || undefined,
       avatar: editFormData.avatar,
     });
-    FirebaseAnalytics.logEvent({ name: 'profile_updated' });
+    logAnalyticsEvent('profile_updated');
     setIsEditing(false);
     toast({ title: 'Profile updated', description: 'Your profile has been saved.' });
   };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -47,7 +47,7 @@ import {
   storeTransactions,
 } from "@/utils/storage-utils";
 import { convertTransactionsToCsv, parseCsvTransactions } from "@/utils/csv";
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 import { Capacitor } from '@capacitor/core';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import { Filesystem, Directory } from '@capacitor/filesystem';
@@ -309,7 +309,7 @@ const Settings = () => {
 
     persistCurrency(currency);
 
-    FirebaseAnalytics.logEvent({ name: 'settings_saved' });
+    logAnalyticsEvent('settings_saved');
 
     toast({
       title: "Settings saved successfully",

--- a/src/services/SmsImportService.ts
+++ b/src/services/SmsImportService.ts
@@ -5,7 +5,7 @@ import {
   getSmsSenderImportMap,
   setSelectedSmsSenders
 } from '@/utils/storage-utils';
-import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 
 // Flags to ensure auto import prompts only appear once per session
 
@@ -24,7 +24,7 @@ export class SmsImportService {
       console.log('AIS-02 checkForNewMessages');
     }
     try {
-      await FirebaseAnalytics.logEvent({ name: 'sms_import_start' });
+      await logAnalyticsEvent('sms_import_start');
       const { auto = false } = opts || {};
 
       const senders = getSelectedSmsSenders();
@@ -103,7 +103,7 @@ export class SmsImportService {
         return;
       }
 
-      await FirebaseAnalytics.logEvent({ name: 'sms_import_complete' });
+      await logAnalyticsEvent('sms_import_complete');
       navigate('/vendor-mapping', { state: { messages: filteredMessages, vendorMap, keywordMap } });
     } catch (error) {
       if (import.meta.env.MODE === 'development') {

--- a/src/utils/firebase-analytics.ts
+++ b/src/utils/firebase-analytics.ts
@@ -1,0 +1,17 @@
+import { Capacitor } from '@capacitor/core';
+import { FirebaseAnalytics } from '@capacitor-firebase/analytics';
+
+/**
+ * Safely log a Firebase Analytics event when running on a native platform.
+ * Errors are silently ignored unless in development mode.
+ */
+export async function logAnalyticsEvent(name: string, params?: Record<string, any>) {
+  if (!Capacitor.isNativePlatform()) return;
+  try {
+    await FirebaseAnalytics.logEvent({ name, params });
+  } catch (err) {
+    if (import.meta.env.MODE === 'development') {
+      console.warn('[FirebaseAnalytics] logEvent failed:', err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- wrap Firebase Analytics usage with a helper that only logs events on native platforms
- use the helper across the app to avoid web runtime errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754eb7c8248333a7248efd3eaed6f1