### PR TITLE
Highlight smart paste autofill fields

### DIFF
--- a/src/components/TransactionEditForm.tsx
+++ b/src/components/TransactionEditForm.tsx
@@ -1020,6 +1020,7 @@ const TransactionEditForm: React.FC<TransactionEditFormProps> = ({
                 'rounded-md border-gray-300 dark:border-gray-600 focus:ring-primary',
                 darkFieldClass
               )}
+              isAutoFilled={isDriven('person', drivenFields)}
             >
               <SelectValue placeholder="Select person" />
             </SelectTrigger>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -42,11 +42,12 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           className={cn(
             "flex h-10 w-full rounded-md border border-input px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm transition-all duration-200",
             !isAutoFilled && "bg-background",
-            isAutoFilled && "border-success bg-success/10 dark:bg-success/10",
+            isAutoFilled && "bg-[#dfffe0]",
             getStateClasses(),
             showStateIcon && (state === 'success' || state === 'error') && "pr-10",
             className
           )}
+          data-driven={isAutoFilled || undefined}
           ref={ref}
           {...props}
         />

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,9 +24,10 @@ const SelectTrigger = React.forwardRef<
     className={cn(
       "flex h-10 w-full items-center justify-between rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       !isAutoFilled && "bg-background",
-      isAutoFilled && "border-success bg-success/10 dark:bg-success/10",
+      isAutoFilled && "bg-[#dfffe0]",
       className
     )}
+    data-driven={isAutoFilled || undefined}
     {...props}
   >
     {children}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -15,10 +15,11 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
 
           isAutoFilled &&
-            "border-success bg-success/10 dark:bg-success-light/50",
+            "bg-[#dfffe0]",
 
           className
         )}
+        data-driven={isAutoFilled || undefined}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
## Summary
- add `data-driven` attr for auto-filled inputs
- highlight auto-filled values with light green background
- highlight 'Person' field when driven by Smart Paste

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install --legacy-peer-deps` *(fails: network issue downloading onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_687b9ba1b7ec833380f6070bebc26bbe