### PR TITLE
Highlight Smart Paste fields

### DIFF
--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -18,6 +18,7 @@ interface DatePickerProps {
   setDate: (date: Date | null) => void;
   placeholder?: string;
   className?: string;
+  isAutoFilled?: boolean;
 }
 
 export function DatePicker({
@@ -25,6 +26,7 @@ export function DatePicker({
   setDate,
   placeholder = "Pick a date",
   className,
+  isAutoFilled,
 }: DatePickerProps) {
   const isNative = Capacitor.isNativePlatform();
 
@@ -44,8 +46,10 @@ export function DatePicker({
           className={cn(
             "w-full pl-10 pr-3 py-2 font-normal",
             !date && "text-muted-foreground",
+            isAutoFilled ? "bg-[#dfffe0]" : "bg-background",
             "dark:bg-white dark:text-black"
           )}
+          data-driven={isAutoFilled || undefined}
           value={date ? format(date, "yyyy-MM-dd") : ""}
           onChange={handleNativeDateSelect}
           placeholder={placeholder}
@@ -63,11 +67,17 @@ export function DatePicker({
           className={cn(
             "w-full justify-start text-left font-normal dark:bg-black dark:text-white",
             !date && "text-muted-foreground",
+            isAutoFilled ? "bg-[#dfffe0]" : "bg-background",
             className
           )}
+          data-driven={isAutoFilled || undefined}
         >
           <CalendarIcon className="mr-2 h-4 w-4" />
-          {date ? format(date, "PPP") : <span>{placeholder}</span>}
+          {date ? (
+            format(date, "PPP")
+          ) : (
+            <span className={cn(isAutoFilled && "bg-[#dfffe0] rounded-md px-1 py-0.5")}>{placeholder}</span>
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -12,8 +12,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-
+          "flex min-h-[80px] w-full rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          isAutoFilled ? "bg-[#dfffe0]" : "bg-background",
           className
         )}
         data-driven={isAutoFilled || undefined}


### PR DESCRIPTION
## Summary
- highlight `Textarea` when Smart Paste auto-fills it
- allow `DatePicker` to show Smart Paste highlighting in both native and popover modes

## Testing
- `npm install --legacy-peer-deps` *(fails: could not resolve onnxruntime-node)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bab87cff88333b054eb71dfaa2777