### PR TITLE
Fix data-driven input background highlight

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -181,7 +181,7 @@
 /* Highlight fields driven by Smart Paste */
 @layer components {
   [data-driven='true'] {
-    background-color: #dfffe0;
+    background-color: #dfffe0 !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak the data-driven CSS rule to always use the light green color

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb2bb1e948333a4d15ad350c111f4