### PR TITLE
Fix select autofill background

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,6 +24,7 @@ const SelectTrigger = React.forwardRef<
     className={cn(
       "flex h-10 w-full items-center justify-between rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       !isAutoFilled && "bg-background",
+      isAutoFilled && "bg-[#dfffe0]",
 
       className
     )}


### PR DESCRIPTION
## Summary
- ensure autofilled SelectTrigger gets light green background

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb764bdd083338fe95c1f131edab6