### PR TITLE
Disable locked settings

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -46,7 +46,7 @@ import {
 } from "lucide-react";
 import { smsPermissionService } from "@/services/SmsPermissionService";
 import { demoTransactionService } from "@/services/DemoTransactionService";
-import { useToast } from "@/components/ui/use-toast";
+import { useToast, toast } from "@/components/ui/use-toast";
 import { useUser } from "@/context/UserContext";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { CURRENCIES } from "@/lib/categories-data";
@@ -61,6 +61,14 @@ import { logAnalyticsEvent } from '@/utils/firebase-analytics';
 import { Capacitor } from '@capacitor/core';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import { Filesystem, Directory } from '@capacitor/filesystem';
+
+const handleLockedFeatureClick = (featureName: string) => {
+  toast({
+    title: `🚧 ${featureName} Coming Soon!`,
+    description:
+      "This feature is currently under development. Stay tuned for exciting updates!",
+  });
+};
 
 const Settings = () => {
   const { toast } = useToast();
@@ -589,17 +597,29 @@ const Settings = () => {
           <p className="text-sm text-muted-foreground">
             Manage notification preferences
           </p>
-          <div className="flex items-center justify-between">
+          <div
+            className="flex items-center justify-between opacity-50 cursor-not-allowed"
+            onClick={(e) => {
+              e.preventDefault();
+              handleLockedFeatureClick('Enable Notifications');
+            }}
+          >
             <div className="space-y-0.5">
-              <Label htmlFor="allow-notifications">Enable Notifications</Label>
+              <Label htmlFor="allow-notifications">
+                <span className="flex items-center space-x-1">
+                  <span>Enable Notifications</span>
+                  <Lock className="ml-2 text-gray-400" size={20} />
+                </span>
+              </Label>
               <p className="text-sm text-muted-foreground">
                 Allow this app to send you notifications
               </p>
             </div>
             <Switch
               id="allow-notifications"
-              checked={notificationsAllowed}
-              onCheckedChange={handleNotificationToggle}
+              checked={false}
+              disabled
+              onClick={() => handleLockedFeatureClick('Enable Notifications')}
             />
           </div>
         </section>
@@ -611,30 +631,54 @@ const Settings = () => {
           <p className="text-sm text-muted-foreground">
             Manage SMS related options
           </p>
-          <div className="flex items-center justify-between">
+          <div
+            className="flex items-center justify-between opacity-50 cursor-not-allowed"
+            onClick={(e) => {
+              e.preventDefault();
+              handleLockedFeatureClick('Enable Background SMS Reading');
+            }}
+          >
             <div className="space-y-0.5">
-              <Label htmlFor="background-sms">Enable Background SMS Reading</Label>
+              <Label htmlFor="background-sms">
+                <span className="flex items-center space-x-1">
+                  <span>Enable Background SMS Reading</span>
+                  <Lock className="ml-2 text-gray-400" size={20} />
+                </span>
+              </Label>
               <p className="text-sm text-muted-foreground">
                 Read incoming SMS in the background
               </p>
             </div>
             <Switch
               id="background-sms"
-              checked={backgroundSmsEnabled}
-              onCheckedChange={handleBackgroundSmsChange}
+              checked={false}
+              disabled
+              onClick={() => handleLockedFeatureClick('Enable Background SMS Reading')}
             />
           </div>
-          <div className="flex items-center justify-between mt-2">
+          <div
+            className="flex items-center justify-between mt-2 opacity-50 cursor-not-allowed"
+            onClick={(e) => {
+              e.preventDefault();
+              handleLockedFeatureClick('Automatic SMS import');
+            }}
+          >
             <div className="space-y-0.5">
-              <Label htmlFor="auto-sms-import">Automatic SMS import</Label>
+              <Label htmlFor="auto-sms-import">
+                <span className="flex items-center space-x-1">
+                  <span>Automatic SMS import</span>
+                  <Lock className="ml-2 text-gray-400" size={20} />
+                </span>
+              </Label>
               <p className="text-sm text-muted-foreground">
                 Check for new SMS on startup
               </p>
             </div>
             <Switch
               id="auto-sms-import"
-              checked={autoImport}
-              onCheckedChange={setAutoImport}
+              checked={false}
+              disabled
+              onClick={() => handleLockedFeatureClick('Automatic SMS import')}
             />
           </div>
         </section>
@@ -662,17 +706,27 @@ const Settings = () => {
             </Button>
           </div>
 
-          <div className="flex items-center justify-between">
+          <div
+            className="flex items-center justify-between opacity-50 cursor-not-allowed"
+            onClick={(e) => {
+              e.preventDefault();
+              handleLockedFeatureClick('Import Data');
+            }}
+          >
             <div>
-              <p className="font-medium">Import Data</p>
+              <p className="font-medium flex items-center space-x-1">
+                <span>Import Data</span>
+                <Lock className="ml-2 text-gray-400" size={20} />
+              </p>
               <p className="text-sm text-muted-foreground">
                 Import transactions from a file
               </p>
             </div>
             <Button
               variant="outline"
-              onClick={handleImportData}
               className="gap-2"
+              disabled
+              onClick={() => handleLockedFeatureClick('Import Data')}
             >
               <UploadCloud size={16} />
               Import

--- a/src/pages/__tests__/SettingsBackgroundSms.test.tsx
+++ b/src/pages/__tests__/SettingsBackgroundSms.test.tsx
@@ -26,7 +26,7 @@ const StateViewer = () => {
 };
 
 describe('Settings background SMS toggle', () => {
-  it('persists preference when toggled', async () => {
+  it('is disabled when feature is locked', () => {
     render(
       <UserProvider>
         <BrowserRouter>
@@ -37,26 +37,6 @@ describe('Settings background SMS toggle', () => {
     );
 
     const toggle = screen.getByLabelText(/enable background sms reading/i);
-    expect(screen.getByTestId('sms-state')).toHaveTextContent('undefined');
-
-    await act(async () => {
-      fireEvent.click(toggle);
-    });
-
-    expect(screen.getByTestId('sms-state')).toHaveTextContent('true');
-  });
-
-  it('reflects existing permission on mount', async () => {
-    render(
-      <UserProvider>
-        <BrowserRouter>
-          <Settings />
-          <StateViewer />
-        </BrowserRouter>
-      </UserProvider>
-    );
-
-    expect(await screen.findByLabelText(/enable background sms reading/i)).toBeChecked();
-    expect(screen.getByTestId('sms-state')).toHaveTextContent('true');
+    expect(toggle).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary
- lock unfinished settings features
- update Settings tests to reflect locked switch
- use shared locked feature toast handler

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e993b9e6c83339db62bd3316e5842